### PR TITLE
Added THREADED config variable, specify json content type

### DIFF
--- a/app/api/report.py
+++ b/app/api/report.py
@@ -1,7 +1,8 @@
 from datetime import datetime
+import json
 from random import randint
 
-from flask import Blueprint, jsonify
+from flask import Blueprint, Response
 
 report_blueprint = Blueprint(name='reports', import_name=__name__)
 
@@ -14,15 +15,17 @@ def get_report(collection_exercise_id):
     downloads = randint(0, accounts_created)
     uploads = randint(0, downloads)
 
-    return jsonify({
-        'metadata': {
-            'collectionExerciseId': collection_exercise_id,
-            'timeUpdated': int(datetime.now().timestamp())
-        },
-        'report': {
-            'downloads': downloads,
-            'uploads': uploads,
-            'accountsCreated': accounts_created,
-            'sampleSize': sample_size
-        }
-    })
+    return Response(
+        json.dumps({
+            'metadata': {
+                'collectionExerciseId': collection_exercise_id,
+                'timeUpdated': int(datetime.now().timestamp())
+            },
+            'report': {
+                'downloads': downloads,
+                'uploads': uploads,
+                'accountsCreated': accounts_created,
+                'sampleSize': sample_size
+            }
+        }),
+        content_type="Application/json")

--- a/app/api/report.py
+++ b/app/api/report.py
@@ -28,4 +28,4 @@ def get_report(collection_exercise_id):
                 'sampleSize': sample_size
             }
         }),
-        content_type="Application/json")
+        content_type='application/json')

--- a/config.py
+++ b/config.py
@@ -5,6 +5,7 @@ class Config:
     DEBUG = os.getenv('DEBUG', False)
     PORT = os.getenv('PORT')
     HOST = os.getenv('HOST')
+    THREADED = os.getenv('THREADED', True)
 
 
 class DevelopmentConfig(Config):

--- a/run.py
+++ b/run.py
@@ -8,4 +8,7 @@ if not os.getenv('APP_SETTINGS'):
 app = create_app()
 
 if __name__ == '__main__':
-    app.run(host=app.config['HOST'], port=int(app.config['PORT']))
+    app.run(
+        host=app.config['HOST'],
+        port=int(app.config['PORT']),
+        threaded=app.config['THREADED'])


### PR DESCRIPTION
### What is the context of this PR?
Turning on threading with flask by default as the client UI currently requires this to function correctly. Also adds a content type header to the report (mock) endpoint.

### How to review 
The report endpoint response should now have a content type header. 
Also the dashboard UI should now be able to function with multiple tabs open.
