### PR TITLE
Set the flask built in 'ENV' config

### DIFF
--- a/config.py
+++ b/config.py
@@ -5,15 +5,16 @@ class Config:
     DEBUG = os.getenv('DEBUG', False)
     PORT = os.getenv('PORT')
     HOST = os.getenv('HOST')
-    THREADED = os.getenv('THREADED', True)
 
 
 class DevelopmentConfig(Config):
     DEBUG = os.getenv('DEBUG', True)
     PORT = os.getenv('PORT', 5000)
     HOST = os.getenv('HOST', 'localhost')
+    ENV = os.getenv('FLASK_ENV', 'development')
 
 
 class TestingConfig(Config):
     PORT = os.getenv('PORT', 5000)
     HOST = os.getenv('HOST', 'localhost')
+    TESTING = True

--- a/run.py
+++ b/run.py
@@ -10,5 +10,4 @@ app = create_app()
 if __name__ == '__main__':
     app.run(
         host=app.config['HOST'],
-        port=int(app.config['PORT']),
-        threaded=app.config['THREADED'])
+        port=int(app.config['PORT']))


### PR DESCRIPTION
### What is the context of this PR?
The latest version of flask now has a built in `ENV` config variable, this PR sets it or reads it from the environment appropriately. The use of `THREADED` is no longer needed since it is now switched on by default in development environments.

### How to review 
Run the app in development mode, the 'Environment' should now be set correctly.
