### PR TITLE
Map Collection Exercises to Surveys

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max_line_length = 120

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,4 @@ script:
 branches:
   only:
     - master
+    - frontend-bootstrap-feature-branch

--- a/Pipfile
+++ b/Pipfile
@@ -11,6 +11,7 @@ flask-cors = "*"
 pytest = "*"
 pytest-cov = "*"
 requests = "*"
+responses = "*"
 
 [dev-packages]
 pylint = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "c092a3723d37ffa55cacf26a9a11ca28fd63fa866c5646ef855670c97475247f"
+            "sha256": "84a484cf311da0433d22df5c694367af2b77c8a8f0df4b18942863ef82877b1e"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -57,6 +57,13 @@
             ],
             "markers": "python_version < '3.2'",
             "version": "==3.5.0"
+        },
+        "cookies": {
+            "hashes": [
+                "sha256:15bee753002dff684987b8df8c235288eb8d45f8191ae056254812dfd42c81d3",
+                "sha256:d6b698788cae4cfa4e62ef8643a9ca332b79bd96cb314294b864ae8d7eb3ee8e"
+            ],
+            "version": "==2.2.1"
         },
         "coverage": {
             "hashes": [
@@ -127,11 +134,11 @@
         },
         "flask-cors": {
             "hashes": [
-                "sha256:a1bb895b3e98b4325743149ebe0e3a0652537b8e37854f942bde7843f822f129",
-                "sha256:bec996f0603a0693c0ea63c8126e5f8e966bb679cf82e6104b254e9c7f3a7d08"
+                "sha256:e4c8fc15d3e4b4cce6d3b325f2bab91e0e09811a61f50d7a53493bc44242a4f1",
+                "sha256:ecc016c5b32fa5da813ec8d272941cfddf5f6bba9060c405a70285415cbf24c9"
             ],
             "index": "pypi",
-            "version": "==3.0.4"
+            "version": "==3.0.6"
         },
         "flask-script": {
             "hashes": [
@@ -142,10 +149,10 @@
         },
         "idna": {
             "hashes": [
-                "sha256:2c6a5de3089009e3da7c5dde64a141dbc8551d5b7f6cf4ed7c2568d0cc520a8f",
-                "sha256:8c7309c718f94b3a625cb648ace320157ad16ff131ae0af362c9f21b80ef6ec4"
+                "sha256:156a6814fb5ac1fc6850fb002e0852d56c0c8d2531923a51032d1b70760e186e",
+                "sha256:684a38a6f903c1d71d6d5fac066b58d7768af4de2b832e426ec79c30daa94a16"
             ],
-            "version": "==2.6"
+            "version": "==2.7"
         },
         "itsdangerous": {
             "hashes": [
@@ -228,11 +235,19 @@
         },
         "requests": {
             "hashes": [
-                "sha256:6a1b267aa90cac58ac3a765d067950e7dbbf75b1da07e895d1f594193a40a38b",
-                "sha256:9c443e7324ba5b85070c4a818ade28bfabedf16ea10206da1132edaa6dda237e"
+                "sha256:63b52e3c866428a224f97cab011de738c36aec0185aa91cfacd418b5d58911d1",
+                "sha256:ec22d826a36ed72a7358ff3fe56cbd4ba69dd7a6718ffd450ff0e9df7a47ce6a"
             ],
             "index": "pypi",
-            "version": "==2.18.4"
+            "version": "==2.19.1"
+        },
+        "responses": {
+            "hashes": [
+                "sha256:c6082710f4abfb60793899ca5f21e7ceb25aabf321560cc0726f8b59006811c9",
+                "sha256:f23a29dca18b815d9d64a516b4a0abb1fbdccff6141d988ad8100facb81cf7b3"
+            ],
+            "index": "pypi",
+            "version": "==0.9.0"
         },
         "six": {
             "hashes": [
@@ -243,10 +258,10 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:06330f386d6e4b195fbfc736b297f58c5a892e4440e54d294d7004e3a9bbea1b",
-                "sha256:cc44da8e1145637334317feebd728bd869a35285b93cbb4cca2577da7e62db4f"
+                "sha256:a68ac5e15e76e7e5dd2b8f94007233e01effe3e50e8daddf69acfd81cb686baf",
+                "sha256:b5725a0bd4ba422ab0e66e89e030c806576753ea3ee08554382c14e685d117b5"
             ],
-            "version": "==1.22"
+            "version": "==1.23"
         },
         "werkzeug": {
             "hashes": [

--- a/app/api/nocache.py
+++ b/app/api/nocache.py
@@ -1,6 +1,7 @@
-from flask import make_response
-from functools import wraps, update_wrapper
 from datetime import datetime
+from functools import wraps, update_wrapper
+
+from flask import make_response
 
 
 def nocache(view):

--- a/app/api/survey.py
+++ b/app/api/survey.py
@@ -1,146 +1,22 @@
-import uuid
-from datetime import datetime
+from flask import Blueprint, render_template, current_app
 
-from flask import Blueprint, render_template, json
 from app.api.nocache import nocache
+from app.common.survey_metadata import fetch_survey_and_collection_exercise_metadata
 
 survey_blueprint = Blueprint(name='survey', import_name=__name__)
-
-all_surveys = {
-    'timestamp': datetime.now().timestamp(),
-    'surveys': [
-        {
-            'shortName': 'BRES',
-            'surveyId': 'cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87',
-            'surveyRef': '221',
-            'collectionExercises': [
-                {
-                    'exerciseRef': 2018,
-                    'collexId': '8d50b535-e852-433c-af1f-e7d027533078'
-                },
-                {
-                    'exerciseRef': 2017,
-                    'collexId': str(uuid.uuid4())
-                },
-                {
-                    'exerciseRef': 2016,
-                    'collexId': str(uuid.uuid4())
-                },
-                {
-                    'exerciseRef': 2015,
-                    'collexId': str(uuid.uuid4())
-                },
-                {
-                    'exerciseRef': 2014,
-                    'collexId': str(uuid.uuid4())
-                },
-                {
-                    'exerciseRef': 2013,
-                    'collexId': str(uuid.uuid4())
-                },
-                {
-                    'exerciseRef': 2012,
-                    'collexId': str(uuid.uuid4())
-                },
-                {
-                    'exerciseRef': 2011,
-                    'collexId': str(uuid.uuid4())
-                },
-                {
-                    'exerciseRef': 2010,
-                    'collexId': str(uuid.uuid4())
-                },
-                {
-                    'exerciseRef': 2009,
-                    'collexId': str(uuid.uuid4())
-                },
-                {
-                    'exerciseRef': 2008,
-                    'collexId': str(uuid.uuid4())
-                },
-                {
-                    'exerciseRef': 2007,
-                    'collexId': str(uuid.uuid4())
-                },
-                {
-                    'exerciseRef': 2006,
-                    'collexId': str(uuid.uuid4())
-                },
-                {
-                    'exerciseRef': 2005,
-                    'collexId': str(uuid.uuid4())
-                },
-                {
-                    'exerciseRef': 2004,
-                    'collexId': str(uuid.uuid4())
-                },
-                {
-                    'exerciseRef': 2003,
-                    'collexId': str(uuid.uuid4())
-                },
-                {
-                    'exerciseRef': 2002,
-                    'collexId': str(uuid.uuid4())
-                },
-                {
-                    'exerciseRef': 2001,
-                    'collexId': str(uuid.uuid4())
-                },
-                {
-                    'exerciseRef': 2000,
-                    'collexId': str(uuid.uuid4())
-                }
-            ]
-        },
-        {
-            'shortName': 'BRAS',
-            'surveyId': str(uuid.uuid4()),
-            'surveyRef': '222',
-            'collectionExercises': [
-                {
-                    'exerciseRef': 2018,
-                    'collexId': str(uuid.uuid4())
-                }
-            ]
-        },
-        {
-            'shortName': 'BRIS',
-            'surveyId': str(uuid.uuid4()),
-            'surveyRef': '223',
-            'collectionExercises': [
-                {
-                    'exerciseRef': 2018,
-                    'collexId': str(uuid.uuid4())
-                }
-            ]
-        },
-        {
-            'shortName': 'BRUS',
-            'surveyId': str(uuid.uuid4()),
-            'surveyRef': '224',
-            'collectionExercises': [
-                {
-                    'exerciseRef': 2018,
-                    'collexId': str(uuid.uuid4())
-                }
-            ]
-        },
-        {
-            'shortName': 'BROS',
-            'surveyId': str(uuid.uuid4()),
-            'surveyRef': '225',
-            'collectionExercises': [
-                {
-                    'exerciseRef': 2018,
-                    'collexId': str(uuid.uuid4())
-                }
-            ]
-        }
-    ]
-}
 
 
 @survey_blueprint.route('/survey/collection-exercise/<collection_exercise_id>', methods=['GET'])
 @nocache
 def get_survey(collection_exercise_id):
-    return render_template('survey.html', collex_id=collection_exercise_id, all_surveys=all_surveys)
+
+    surveys_metadata, collection_exercise_metadata = fetch_survey_and_collection_exercise_metadata()
+    collection_exercise_name = collection_exercise_metadata[collection_exercise_id]['collexName']
+
+    return render_template(
+        'survey.html',
+        collex_id=collection_exercise_id,
+        all_surveys=surveys_metadata,
+        collection_exercise_name=collection_exercise_name,
+        reporting_url=current_app.config['REPORTING_URL']
+    )

--- a/app/api/surveys.py
+++ b/app/api/surveys.py
@@ -4,6 +4,7 @@ import uuid
 
 from flask import Blueprint, Response
 
+from app.common.survey_metadata import map_surveys_to_collection_exercises
 from app.controllers.collection_exercise_controller import get_collection_exercise_list
 from app.controllers.survey_controller import get_survey_list
 
@@ -15,7 +16,7 @@ surveys_blueprint = Blueprint(name='surveys', import_name=__name__)
 def get_surveys():
     surveys = get_survey_list()
     collexs = get_collection_exercise_list()
-    survey_data = _process_survey_metadata(surveys, collexs)
+    survey_data = map_surveys_to_collection_exercises(surveys, collexs)
     return Response(
         json.dumps({
             'timestamp': datetime.now().timestamp(),
@@ -24,7 +25,6 @@ def get_surveys():
         content_type='application/json')
 
 
-# TODO remove once no longer required
 # Example response endpoint for convenience in development
 @surveys_blueprint.route('/surveys/example', methods=['GET'])
 def get_surveys_example():
@@ -120,4 +120,3 @@ def _process_survey_metadata(surveys, collection_exercises):
         )
 
     return list(survey_data.values())
-

--- a/app/common/survey_metadata.py
+++ b/app/common/survey_metadata.py
@@ -25,7 +25,7 @@ def map_surveys_to_collection_exercises(surveys, collection_exercises) -> list:
             if str(e) == f"'{collection_exercise['surveyId']}'":
                 raise UnknownSurveyError(
                     message='Reference to unknown survey id in collection exercise',
-                    survey_id=['surveyId'])
+                    survey_id=['surveyId']) from e
             else:
                 raise
 

--- a/app/common/survey_metadata.py
+++ b/app/common/survey_metadata.py
@@ -1,0 +1,55 @@
+from app.controllers.collection_exercise_controller import get_collection_exercise_list
+from app.controllers.survey_controller import get_survey_list
+from app.exceptions import UnknownSurveyError
+
+
+def map_surveys_to_collection_exercises(surveys, collection_exercises) -> list:
+    survey_data = {
+        survey['id']: {
+            'surveyId': survey['id'],
+            'shortName': survey['shortName'],
+            'surveyRef': survey['surveyRef'],
+            'collectionExercises': []
+        } for survey in surveys
+    }
+
+    for collection_exercise in collection_exercises:
+        try:
+            survey_data[collection_exercise['surveyId']]['collectionExercises'].append(
+                {
+                    'collexId': collection_exercise['id'],
+                    'collexName': collection_exercise['name']
+                }
+            )
+        except KeyError as e:
+            if str(e) == f"'{collection_exercise['surveyId']}'":
+                raise UnknownSurveyError(
+                    message='Reference to unknown survey id in collection exercise',
+                    survey_id=['surveyId'])
+            else:
+                raise
+
+    return list(survey_data.values())
+
+
+def map_collection_exercise_id_to_survey_id(surveys_to_collection_exercises) -> dict:
+    collection_exercises_to_survey_ids = {}
+    for survey in surveys_to_collection_exercises:
+        for collection_exercise in survey['collectionExercises']:
+            collection_exercises_to_survey_ids[collection_exercise['collexId']] = {
+                'surveyId': survey['surveyId'],
+                'shortName': survey['shortName'],
+                'collexName': collection_exercise['collexName']
+            }
+
+    return collection_exercises_to_survey_ids
+
+
+def fetch_survey_and_collection_exercise_metadata() -> (list, dict):
+    collection_exercises = get_collection_exercise_list()
+    surveys = get_survey_list()
+
+    surveys_to_collection_exercises = map_surveys_to_collection_exercises(surveys, collection_exercises)
+    collection_exercises_to_survey_ids = map_collection_exercise_id_to_survey_id(surveys_to_collection_exercises)
+
+    return surveys_to_collection_exercises, collection_exercises_to_survey_ids

--- a/app/controllers/collection_exercise_controller.py
+++ b/app/controllers/collection_exercise_controller.py
@@ -1,18 +1,14 @@
-import requests
-
 from flask import current_app, abort
+import requests
 from requests.auth import HTTPBasicAuth
 
 
 def get_collection_exercise_list():
-    current_app.logger.debug('Retrieving collection exercises list')
-    url = f'{current_app.config["COLLECTION_EXERCISE_URL"]}/collectionexercises'
+    url = f'{current_app.config["COLLECTION_EXERCISE_URL"]}collectionexercises'
     response = requests.get(
         url,
         auth=HTTPBasicAuth(current_app.config['AUTH_USERNAME'],
                            current_app.config['AUTH_PASSWORD']))
     if response.status_code != 200:
-        current_app.logger.error('Failed to retrieve collection exercises list')
         abort(500)
-    current_app.logger.debug('Successfully retrieved collection exercises list')
     return response.json()

--- a/app/controllers/survey_controller.py
+++ b/app/controllers/survey_controller.py
@@ -1,18 +1,14 @@
+from flask import current_app as app, abort
 import requests
-
-from flask import current_app, abort
 from requests.auth import HTTPBasicAuth
 
 
 def get_survey_list():
-    current_app.logger.debug('Retrieving surveys list')
-    url = f'{current_app.config["SURVEY_URL"]}/surveys'
+    url = f'{app.config["SURVEY_URL"]}surveys'
     response = requests.get(
         url,
-        auth=HTTPBasicAuth(current_app.config['AUTH_USERNAME'],
-                           current_app.config['AUTH_PASSWORD']))
+        auth=HTTPBasicAuth(app.config['AUTH_USERNAME'],
+                           app.config['AUTH_PASSWORD']))
     if response.status_code != 200:
-        current_app.logger.error('Failed to retrieve survey list')
         abort(500)
-    current_app.logger.debug('Successfully retrieved surveys list')
     return response.json()

--- a/app/exceptions/__init__.py
+++ b/app/exceptions/__init__.py
@@ -1,0 +1,3 @@
+from app.exceptions.exceptions import ApiError, UnknownSurveyError
+
+__all__ = ['ApiError', 'UnknownSurveyError']

--- a/app/exceptions/exceptions.py
+++ b/app/exceptions/exceptions.py
@@ -1,0 +1,13 @@
+class ApiError(Exception):
+
+    def __init__(self, message):
+        super(ApiError, self).__init__(message)
+        self.message = message
+
+
+class UnknownSurveyError(Exception):
+
+    def __init__(self, message, survey_id):
+        super(UnknownSurveyError, self).__init__(message, survey_id)
+        self.message = message
+        self.survey_id = survey_id

--- a/config.py
+++ b/config.py
@@ -7,6 +7,7 @@ class Config:
     HOST = os.getenv('HOST')
     COLLECTION_EXERCISE_URL = os.getenv('COLLECTION_EXERCISE_URL')
     SURVEY_URL = os.getenv('SURVEY_URL')
+    REPORTING_URL = os.getenv('REPORTING_URL')
     AUTH_USERNAME = os.getenv('AUTH_USERNAME')
     AUTH_PASSWORD = os.getenv('AUTH_PASSWORD')
 
@@ -16,13 +17,14 @@ class DevelopmentConfig(Config):
     PORT = os.getenv('PORT', 5000)
     HOST = os.getenv('HOST', 'localhost')
     ENV = os.getenv('FLASK_ENV', 'development')
-    COLLECTION_EXERCISE_URL = os.getenv('COLLECTION_EXERCISE_URL', 'http://localhost:8145')
-    SURVEY_URL = os.getenv('SURVEY_URL', 'http://localhost:8080')
+    COLLECTION_EXERCISE_URL = os.getenv('COLLECTION_EXERCISE_URL', 'http://localhost:8145/')
+    SURVEY_URL = os.getenv('SURVEY_URL', 'http://localhost:8080/')
+    REPORTING_URL = os.getenv('REPORTING_URL', 'http://localhost:8084/')
     AUTH_USERNAME = os.getenv('AUTH_USERNAME', 'admin')
     AUTH_PASSWORD = os.getenv('AUTH_PASSWORD', 'secret')
 
 
-class TestingConfig(Config):
+class TestingConfig(DevelopmentConfig):
     PORT = os.getenv('PORT', 5000)
     HOST = os.getenv('HOST', 'localhost')
     TESTING = True

--- a/tests/app/api/test_report.py
+++ b/tests/app/api/test_report.py
@@ -4,10 +4,10 @@ from tests.app.app_context_test_case import AppContextTestCase
 class TestReport(AppContextTestCase):
 
     def test_get_report(self):
-        response = self.test_client.get('/report/collection_exercise_id')
+        response = self.test_client.get('/report/collection-exercise/test-id')
         self.assertEqual(response.status_code, 200)
-        self.assertIn(b'collection_exercise_id', response.data)
-        self.assertIn(b'accountsCreated', response.data)
+        self.assertIn(b'test-id', response.data)
+        self.assertIn(b'accountsEnrolled', response.data)
         self.assertIn(b'sampleSize', response.data)
         self.assertIn(b'downloads', response.data)
         self.assertIn(b'uploads', response.data)

--- a/tests/app/app_context_test_case.py
+++ b/tests/app/app_context_test_case.py
@@ -9,4 +9,5 @@ class AppContextTestCase(unittest.TestCase):
     def setUp(self):
         app = create_app()
         app.config.from_object(TestingConfig)
+        self.app = app
         self.test_client = app.test_client()

--- a/tests/app/app_context_test_case.py
+++ b/tests/app/app_context_test_case.py
@@ -7,7 +7,6 @@ from config import TestingConfig
 class AppContextTestCase(unittest.TestCase):
 
     def setUp(self):
-        app = create_app()
-        app.config.from_object(TestingConfig)
-        self.app = app
-        self.test_client = app.test_client()
+        self.app = create_app()
+        self.app.config.from_object(TestingConfig)
+        self.test_client = self.app.test_client()

--- a/tests/app/common/test_survey_metadata.py
+++ b/tests/app/common/test_survey_metadata.py
@@ -1,0 +1,63 @@
+import json
+import os
+import unittest
+
+from app.common.survey_metadata import map_surveys_to_collection_exercises, map_collection_exercise_id_to_survey_id
+from app.exceptions import UnknownSurveyError
+
+
+class TestSurveyMetadata(unittest.TestCase):
+
+    this_file_path = os.path.dirname(__file__)
+
+    with open(os.path.join(this_file_path, '../../test_data/get_surveys_response.json')) as fp:
+        surveys_response = json.load(fp)
+
+    with open(os.path.join(this_file_path, '../../test_data/get_collection_exercises_response.json')) as fp:
+        collection_exercises_response = json.load(fp)
+
+    def test_map_surveys_to_collection_exercises(self):
+        expected_result = [
+            {
+                'surveyId': 'cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87',
+                'shortName': 'BRES',
+                'surveyRef': '221',
+                'collectionExercises': [
+                    {
+                        'collexId': '14fb3e68-4dca-46db-bf49-04b84e07e77c',
+                        'collexName': 'BRES_2017'
+                    }
+                ]
+            },
+            {
+                'surveyId': '04dbb407-4438-4f89-acc4-53445d75330c',
+                'shortName': 'AOFDI',
+                'surveyRef': '063',
+                'collectionExercises': []
+            }
+        ]
+
+        actual_result = map_surveys_to_collection_exercises(
+            self.surveys_response,
+            self.collection_exercises_response)
+
+        self.assertEqual(expected_result, actual_result)
+
+    def test_map_collection_exercise_id_to_survey_id(self):
+        expected_result = {
+            '14fb3e68-4dca-46db-bf49-04b84e07e77c': {
+                'surveyId': 'cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87',
+                'shortName': 'BRES',
+                'collexName': 'BRES_2017'
+            }
+        }
+
+        actual_result = map_collection_exercise_id_to_survey_id(
+            map_surveys_to_collection_exercises(self.surveys_response, self.collection_exercises_response))
+
+        self.assertEqual(expected_result, actual_result)
+
+    def test_unknown_survey_id_raises_unknown_survey_exception(self):
+        with self.assertRaises(UnknownSurveyError) as e:
+            map_surveys_to_collection_exercises({}, self.collection_exercises_response)
+            self.assertEqual(e.survey_id, 'cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87')

--- a/tests/app/controllers/test_collection_exercise_controller.py
+++ b/tests/app/controllers/test_collection_exercise_controller.py
@@ -1,0 +1,27 @@
+import json
+import os
+
+import responses
+
+from app.controllers.collection_exercise_controller import get_collection_exercise_list
+from tests.app.app_context_test_case import AppContextTestCase
+
+
+class TestSurveyController(AppContextTestCase):
+    this_file_path = os.path.dirname(__file__)
+
+    with open(os.path.join(this_file_path, '../../test_data/get_collection_exercises_response.json')) as fp:
+        collection_exercises_response = json.load(fp)
+
+    @responses.activate
+    def test_get_survey_list_success(self):
+        with self.app.app_context():
+            responses.add(
+                responses.GET,
+                self.app.config['COLLECTION_EXERCISE_URL'] + 'collectionexercises',
+                json=self.collection_exercises_response,
+                status=200)
+
+            controller_output = get_collection_exercise_list()
+
+        self.assertEqual(self.collection_exercises_response, controller_output)

--- a/tests/app/controllers/test_survey_controller.py
+++ b/tests/app/controllers/test_survey_controller.py
@@ -1,0 +1,27 @@
+import json
+import os
+
+import responses
+
+from app.controllers.survey_controller import get_survey_list
+from tests.app.app_context_test_case import AppContextTestCase
+
+
+class TestSurveyController(AppContextTestCase):
+    this_file_path = os.path.dirname(__file__)
+
+    with open(os.path.join(this_file_path, '../../test_data/get_surveys_response.json')) as fp:
+        surveys_response = json.load(fp)
+
+    @responses.activate
+    def test_get_survey_list_success(self):
+        with self.app.app_context():
+            responses.add(
+                responses.GET,
+                self.app.config['SURVEY_URL'] + 'surveys',
+                json=self.surveys_response,
+                status=200)
+
+            controller_output = get_survey_list()
+
+        self.assertEqual(self.surveys_response, controller_output)

--- a/tests/test_data/get_collection_exercises_response.json
+++ b/tests/test_data/get_collection_exercises_response.json
@@ -1,0 +1,33 @@
+[
+  {
+    "id": "14fb3e68-4dca-46db-bf49-04b84e07e77c",
+    "surveyId": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87",
+    "name": "BRES_2017",
+    "actualExecutionDateTime": null,
+    "scheduledExecutionDateTime": "2017-09-10T23:00:00.000Z",
+    "scheduledStartDateTime": "2017-09-11T23:00:00.000Z",
+    "actualPublishDateTime": null,
+    "periodStartDateTime": "2017-09-14T23:00:00.000Z",
+    "periodEndDateTime": "2017-09-15T22:59:59.000Z",
+    "scheduledReturnDateTime": "2017-10-06T00:00:00.000Z",
+    "scheduledEndDateTime": "2018-06-29T23:00:00.000Z",
+    "executedBy": null,
+    "state": "CREATED",
+    "caseTypes": [
+      {
+        "actionPlanId": "e71002ac-3575-47eb-b87f-cd9db92bf9a7",
+        "sampleUnitType": "B"
+      },
+      {
+        "actionPlanId": "0009e978-0932-463b-a2a1-b45cb3ffcb2a",
+        "sampleUnitType": "BI"
+      }
+    ],
+    "exerciseRef": "221_201712",
+    "userDescription": null,
+    "created": null,
+    "updated": null,
+    "deleted": false,
+    "validationErrors": null
+  }
+]

--- a/tests/test_data/get_surveys_response.json
+++ b/tests/test_data/get_surveys_response.json
@@ -1,0 +1,18 @@
+[
+  {
+    "id": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87",
+    "shortName": "BRES",
+    "longName": "Business Register and Employment Survey",
+    "surveyRef": "221",
+    "legalBasis": "Statistics of Trade Act 1947",
+    "legalBasisRef": "STA1947"
+  },
+  {
+    "id": "04dbb407-4438-4f89-acc4-53445d75330c",
+    "shortName": "AOFDI",
+    "longName": "Annual Outward Foreign Direct Investment Survey",
+    "surveyRef": "063",
+    "legalBasis": "Statistics of Trade Act 1947",
+    "legalBasisRef": "STA1947"
+  }
+]


### PR DESCRIPTION
### What is the context of this PR?
The app needs to be able to fetch and map survey and collection exercise details to one another, this PR adds the mapping functions and fixes the controllers which had issues and were untested.

* Fixes issue where controllers require app_context, removed the logging until a proper logger is set up
* Added basic unit tests for the existing controllers
* Added mapping functions to map collection exercises to survey details and survey ID's
* Added unit tests for mapping function
* Added exception for the case where a collection exercise references an unknown survey
* Added API exception for use if an external API errors
* Added .flake8 file to increase the flake8 line length check to 120 characters
* Added feature branch to travis build

### How to review 
Check code quality and style, check all tests and valid and still pass.