### PR TITLE
Removing caching on dashboard

### DIFF
--- a/app/views/dashboard.py
+++ b/app/views/dashboard.py
@@ -25,6 +25,7 @@ def get_survey(collection_exercise_id):
         reporting_refresh_cycle=current_app.config['REPORTING_REFRESH_CYCLE']
     )
 
+
 @dashboard_blueprint.after_request
 def add_cache_control(response):
     response.cache_control.no_cache = True

--- a/app/views/dashboard.py
+++ b/app/views/dashboard.py
@@ -24,3 +24,8 @@ def get_survey(collection_exercise_id):
         reporting_url=current_app.config['REPORTING_URL'],
         reporting_refresh_cycle=current_app.config['REPORTING_REFRESH_CYCLE']
     )
+
+@dashboard_blueprint.after_request
+def add_cache_control(response):
+    response.cache_control.no_cache = True
+    return response


### PR DESCRIPTION
### What is the context of this PR?
The dashboard is currently keeping javascript styles so i've disabled caching so it would refresh on every refresh.
### How to review 
Load the dashboard and using inspect, go on Network and look at what is being downloaded every-time the website is reloaded and javascript styles shouldn't be cached.