### PR TITLE
Add check for missing config variables at app startup

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,17 @@
-### What is the context of this PR?
-Describe what you have changed and why, link to other PRs or Issues as appropriate.
+# Motivation and Context
+<!--- Why is this change required? What problem does it solve? -->
 
-### How to review 
-Describe the steps required to test the changes (include screenshots if appropriate).
+# What has changed
+<!--- What code changes has been made -->
+<!--- Has there been any refactoring -->
+<!--- What tests have been written -->
+
+# How to test?
+<!--- Describe in detail how you tested your changes. -->
+<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
+<!--- Are there any automated tests that mean changes don't need to be manually changed -->
+
+# Links
+<!--- Add any links to issues (trello, github issues) -->
+<!--- Links to any documentation -->
+<!--- Links to any related PRs -->

--- a/app/exceptions/__init__.py
+++ b/app/exceptions/__init__.py
@@ -1,3 +1,3 @@
-from app.exceptions.exceptions import ApiError, UnknownSurveyError
+from app.exceptions.exceptions import UnknownSurveyError, MissingConfigError
 
-__all__ = ['ApiError', 'UnknownSurveyError']
+__all__ = ['UnknownSurveyError', 'MissingConfigError']

--- a/app/exceptions/exceptions.py
+++ b/app/exceptions/exceptions.py
@@ -1,13 +1,13 @@
-class ApiError(Exception):
-
-    def __init__(self, message):
-        super(ApiError, self).__init__(message)
-        self.message = message
-
-
 class UnknownSurveyError(Exception):
 
     def __init__(self, message, survey_id):
         super(UnknownSurveyError, self).__init__(message, survey_id)
         self.message = message
         self.survey_id = survey_id
+
+
+class MissingConfigError(Exception):
+
+    def __init__(self, keys: set):
+        super(MissingConfigError, self).__init__(keys)
+        self.keys = keys

--- a/app/setup.py
+++ b/app/setup.py
@@ -7,17 +7,20 @@ from flask_cors import CORS
 import structlog
 from structlog.processors import JSONRenderer
 
+from app.exceptions import MissingConfigError
 import config
 
 
 def create_app():
+
+    app_config = getattr(config, os.getenv('APP_SETTINGS', 'Config'))
+    check_required_config(app_config)
 
     app = Flask(__name__)
     app.url_map.strict_slashes = False
 
     CORS(app)
 
-    app_config = getattr(config, os.getenv('APP_SETTINGS', 'Config'))
     app.config.from_object(app_config)
 
     _configure_logger(level=app.config['LOGGING_LEVEL'],
@@ -64,3 +67,9 @@ def _configure_logger(level='INFO', indent=False):
         wrapper_class=structlog.stdlib.BoundLogger,
         cache_logger_on_first_use=True,
     )
+
+
+def check_required_config(app_config):
+    missing_vars = {var for var in config.REQUIRED_ENVIRONMENT_VARIABLES if vars(app_config).get(var) is None}
+    if missing_vars:
+        raise MissingConfigError(missing_vars)

--- a/app/setup.py
+++ b/app/setup.py
@@ -70,6 +70,6 @@ def _configure_logger(level='INFO', indent=False):
 
 
 def check_required_config(app_config):
-    missing_vars = {var for var in config.REQUIRED_ENVIRONMENT_VARIABLES if vars(app_config).get(var) is None}
+    missing_vars = {var for var in config.REQUIRED_ENVIRONMENT_VARIABLES if not vars(app_config).get(var)}
     if missing_vars:
         raise MissingConfigError(missing_vars)

--- a/config.py
+++ b/config.py
@@ -1,6 +1,18 @@
 from distutils.util import strtobool
 import os
 
+REQUIRED_ENVIRONMENT_VARIABLES = {
+    'DEBUG',
+    'PORT',
+    'HOST',
+    'COLLECTION_EXERCISE_URL',
+    'SURVEY_URL',
+    'REPORTING_URL',
+    'REPORTING_REFRESH_CYCLE',
+    'AUTH_USERNAME',
+    'AUTH_PASSWORD'
+}
+
 
 class Config:
     DEBUG = os.getenv('DEBUG', False)

--- a/config.py
+++ b/config.py
@@ -2,7 +2,6 @@ from distutils.util import strtobool
 import os
 
 REQUIRED_ENVIRONMENT_VARIABLES = {
-    'DEBUG',
     'PORT',
     'HOST',
     'COLLECTION_EXERCISE_URL',
@@ -44,9 +43,13 @@ class DevelopmentConfig(Config):
 
 class TestingConfig(Config):
     testing_url = 'http://test/'
-    COLLECTION_EXERCISE_URL = os.getenv('COLLECTION_EXERCISE_URL', testing_url)
-    SURVEY_URL = os.getenv('SURVEY_URL', testing_url)
-    REPORTING_URL = os.getenv('REPORTING_URL', testing_url)
-    PORT = os.getenv('PORT', 5000)
-    HOST = os.getenv('HOST', 'localhost')
+    COLLECTION_EXERCISE_URL = testing_url
+    SURVEY_URL = testing_url
+    REPORTING_URL = testing_url
+    PORT = 5000
+    HOST = 'localhost'
     TESTING = True
+    ENV = 'testing'
+    REPORTING_REFRESH_CYCLE = 10000
+    AUTH_USERNAME = 'admin'
+    AUTH_PASSWORD = 'secret'

--- a/tests/app/__init__.py
+++ b/tests/app/__init__.py
@@ -1,12 +1,12 @@
+import os
 import unittest
 
 from app.setup import create_app
-from config import TestingConfig
 
 
 class AppContextTestCase(unittest.TestCase):
 
     def setUp(self):
+        os.environ['APP_SETTINGS'] = 'TestingConfig'
         self.app = create_app()
-        self.app.config.from_object(TestingConfig)
         self.test_client = self.app.test_client()

--- a/tests/app/test_setup.py
+++ b/tests/app/test_setup.py
@@ -5,7 +5,7 @@ from app.setup import check_required_config
 from config import DevelopmentConfig
 
 
-class MyTestCase(unittest.TestCase):
+class TestSetup(unittest.TestCase):
     def test_incomplete_config_raises_exception(self):
 
         class IncompleteConfig:

--- a/tests/app/test_setup.py
+++ b/tests/app/test_setup.py
@@ -1,0 +1,20 @@
+import unittest
+
+from app.exceptions import MissingConfigError
+from app.setup import check_required_config
+from config import DevelopmentConfig
+
+
+class MyTestCase(unittest.TestCase):
+    def test_incomplete_config_raises_exception(self):
+
+        class IncompleteConfig:
+            HOST = 'TEST'
+
+        with self.assertRaises(MissingConfigError) as e:
+            check_required_config(IncompleteConfig)
+            self.assertIn('PORT', e.keys, msg='Required variable which is missing is not present in exception')
+
+    @staticmethod
+    def test_development_config_successfully_checked():
+        check_required_config(DevelopmentConfig)

--- a/tests/app/test_setup.py
+++ b/tests/app/test_setup.py
@@ -7,13 +7,29 @@ from config import DevelopmentConfig
 
 class TestSetup(unittest.TestCase):
     def test_incomplete_config_raises_exception(self):
-
         class IncompleteConfig:
             HOST = 'TEST'
 
-        with self.assertRaises(MissingConfigError) as e:
+        with self.assertRaises(MissingConfigError) as exception_context:
             check_required_config(IncompleteConfig)
-            self.assertIn('PORT', e.keys, msg='Required variable which is missing is not present in exception')
+
+        self.assertIn('PORT',
+                      exception_context.exception.keys,
+                      msg='"PORT" variable which is missing is not present in exception')
+        self.assertNotIn('HOST',
+                         exception_context.exception.keys,
+                         msg='"HOST" variable in exception even though HOST should be set')
+
+    def test_empty_string_in_config_raises_exception(self):
+        class IncompleteConfig:
+            HOST = ''
+
+        with self.assertRaises(MissingConfigError) as exception_context:
+            check_required_config(IncompleteConfig)
+
+        self.assertIn('HOST',
+                      exception_context.exception.keys,
+                      msg='"HOST" variable which is missing is not present in exception')
 
     @staticmethod
     def test_development_config_successfully_checked():


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Previously the app could start up successfully even if it was missing some required config, causing potentially unpredictable behaviour and potential run time errors. This PR solves this problem by checking all the required config is set at app start up time.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
* Add set of required config variables
* Check for missing config at app start up
* Add tests for checking configuration
* Delete unused custom exception
* Update PR template

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
The app should start normally with DevelopmentConfig set.
If you try to start up with production config but leave a required variable missing, the app should throw an exception telling you what it is missing and refuse to start up.

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/yQX4fTmk/48-app-should-fail-on-start-up-if-it-is-missing-config

