### PR TITLE
Add filters to avoid showing social surveys while they are not supported

### DIFF
--- a/scripts/mock_services.py
+++ b/scripts/mock_services.py
@@ -10,7 +10,9 @@ app.env = 'development'
 CORS(app)
 
 
-@app.route('/reporting-api/v1/response-dashboard/<collection_instrument_type>/collection-exercise/<collection_exercise_id>', methods=['GET'])
+@app.route(
+    '/reporting-api/v1/response-dashboard/<collection_instrument_type>/collection-exercise/<collection_exercise_id>',
+    methods=['GET'])
 def get_report(collection_instrument_type, collection_exercise_id):
     rand_gen = SystemRandom()
 
@@ -63,7 +65,8 @@ def get_surveys():
                     "longName": "Business Register and Employment Survey",
                     "surveyRef": "221",
                     "legalBasis": "Statistics of Trade Act 1947",
-                    "legalBasisRef": "STA1947"
+                    "legalBasisRef": "STA1947",
+                    "surveyType": "Business"
                 },
                 {
                     "id": "04dbb407-4438-4f89-acc4-53445d75330c",
@@ -71,13 +74,24 @@ def get_surveys():
                     "longName": "Annual Outward Foreign Direct Investment Survey",
                     "surveyRef": "063",
                     "legalBasis": "Statistics of Trade Act 1947",
-                    "legalBasisRef": "STA1947"
+                    "legalBasisRef": "STA1947",
+                    "surveyType": "Business"
                 },
                 {
                     "id": "04dbb407-4438-4f89-acc4-53445d753111",
                     "shortName": "QBS",
                     "longName": "Quarterly Business Survey",
                     "surveyRef": "064",
+                    "legalBasis": "Statistics of Trade Act 1947",
+                    "legalBasisRef": "STA1947",
+                    "surveyType": "Business"
+                },
+                {
+                    "id": "56dbb407-4438-4f89-acc4-53445d753111",
+                    "shortName": "LMS",
+                    "longName": "Labour Market Survey",
+                    "surveyRef": "999",
+                    "surveyType": "Social",
                     "legalBasis": "Statistics of Trade Act 1947",
                     "legalBasisRef": "STA1947"
                 }

--- a/tests/app/common/test_survey_metadata.py
+++ b/tests/app/common/test_survey_metadata.py
@@ -111,7 +111,7 @@ class TestSurveyMetadata(AppContextTestCase):
                  'shortName': 'BRES',
                  'surveyType': 'Business',
                  'surveyId': 'cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87',
-                 'userDescription': 'January 2018'},
+                 'userDescription': 'January 2018'}
         }
 
         actual_result = map_collection_exercise_id_to_survey_id(
@@ -179,8 +179,7 @@ class TestSurveyMetadata(AppContextTestCase):
                  'shortName': 'QBS',
                  'surveyType': 'Business',
                  'surveyId': '04dbb407-4438-4f89-acc4-53445d753111',
-                 'userDescription': 'Quarterly '
-                                    'Business Survey'},
+                 'userDescription': 'Quarterly Business Survey'},
             '24fb3e68-4dca-46db-bf49-04b84e07e77c':
                 {'collectionInstrumentType': 'seft',
                  'exerciseRef': '201801',
@@ -204,10 +203,14 @@ class TestSurveyMetadata(AppContextTestCase):
         collection_exercises, surveys = self.fetch_mock_survey_and_collection_exercises_response()
 
         for survey in surveys:
-            self.assertEqual(survey['surveyType'], 'Business')
+            self.assertEqual(survey['surveyType'],
+                             'Business',
+                             'Found survey type not equal to "Business" in surveys list')
 
         for collection_exercise in collection_exercises.values():
-            self.assertEqual(collection_exercise['surveyType'], 'Business')
+            self.assertEqual(collection_exercise['surveyType'],
+                             'Business',
+                             'Found survey type not equal to "Business" in collection exercise map')
 
     def fetch_mock_survey_and_collection_exercises_response(self):
         # Requires @responses.activate

--- a/tests/app/common/test_survey_metadata.py
+++ b/tests/app/common/test_survey_metadata.py
@@ -18,11 +18,12 @@ class TestSurveyMetadata(AppContextTestCase):
     with open(os.path.join(this_file_path, '../../test_data/get_collection_exercises_response.json')) as fp:
         collection_exercises_response = json.load(fp)
 
-    def test_map_surveys_to_collection_exercises_for_seft(self):
+    def test_map_surveys_to_collection_exercises(self):
         expected_result = [
             {
                 'surveyId': 'cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87',
                 'shortName': 'BRES',
+                'surveyType': 'Business',
                 'longName': 'Business Register and Employment Survey',
                 'collectionInstrumentType': 'seft',
                 'surveyRef': '221',
@@ -42,6 +43,7 @@ class TestSurveyMetadata(AppContextTestCase):
             {
                 'surveyId': '04dbb407-4438-4f89-acc4-53445d75330c',
                 'shortName': 'AOFDI',
+                'surveyType': 'Business',
                 'collectionInstrumentType': 'seft',
                 'longName': 'Annual Outward Foreign Direct Investment Survey',
                 'surveyRef': '063',
@@ -51,6 +53,7 @@ class TestSurveyMetadata(AppContextTestCase):
                 'surveyId': '04dbb407-4438-4f89-acc4-53445d753111',
                 'collectionInstrumentType': 'eq',
                 'shortName': 'QBS',
+                'surveyType': 'Business',
                 'longName': 'Quarterly Business Survey',
                 'surveyRef': '064',
                 'collectionExercises': [
@@ -60,57 +63,15 @@ class TestSurveyMetadata(AppContextTestCase):
                         'exerciseRef': '201812'
                     }
                 ]
-            }
-        ]
-
-        actual_result = map_surveys_to_collection_exercises(
-            self.surveys_response,
-            self.collection_exercises_response)
-
-        self.assertEqual(expected_result, actual_result)
-
-    def test_map_surveys_to_collection_exercises_for_eq(self):
-        expected_result = [
-            {
-                'surveyId': 'cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87',
-                'collectionInstrumentType': 'seft',
-                'shortName': 'BRES',
-                'longName': 'Business Register and Employment Survey',
-                'surveyRef': '221',
-                'collectionExercises': [
-                    {
-                        'collectionExerciseId': '14fb3e68-4dca-46db-bf49-04b84e07e77c',
-                        'userDescription': 'December 2017',
-                        'exerciseRef': '201712'
-                    },
-                    {
-                        'collectionExerciseId': '24fb3e68-4dca-46db-bf49-04b84e07e77c',
-                        'userDescription': 'January 2018',
-                        'exerciseRef': '201801'
-                    }
-                ]
             },
             {
-                'surveyId': '04dbb407-4438-4f89-acc4-53445d75330c',
-                'collectionInstrumentType': 'seft',
-                'shortName': 'AOFDI',
-                'longName': 'Annual Outward Foreign Direct Investment Survey',
-                'surveyRef': '063',
-                'collectionExercises': []
-            },
-            {
-                'surveyId': '04dbb407-4438-4f89-acc4-53445d753111',
+                'surveyId': '56dbb407-4438-4f89-acc4-53445d753111',
                 'collectionInstrumentType': 'eq',
-                'shortName': 'QBS',
-                'longName': 'Quarterly Business Survey',
-                'surveyRef': '064',
-                'collectionExercises': [
-                    {
-                        'collectionExerciseId': '14fb3e68-4dca-46db-bf49-04b84e07e777',
-                        'userDescription': 'Quarterly Business Survey',
-                        'exerciseRef': '201812'
-                    }
-                ]
+                'shortName': 'LMS',
+                'longName': 'Labour Market Survey',
+                'surveyRef': '999',
+                'surveyType': 'Social',
+                'collectionExercises': []
             }
         ]
 
@@ -128,6 +89,7 @@ class TestSurveyMetadata(AppContextTestCase):
                  'longName': 'Quarterly Business '
                              'Survey',
                  'shortName': 'QBS',
+                 'surveyType': 'Business',
                  'surveyId': '04dbb407-4438-4f89-acc4-53445d753111',
                  'userDescription': 'Quarterly '
                                     'Business Survey'},
@@ -138,6 +100,7 @@ class TestSurveyMetadata(AppContextTestCase):
                  'longName': 'Business Register and '
                              'Employment Survey',
                  'shortName': 'BRES',
+                 'surveyType': 'Business',
                  'surveyId': 'cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87',
                  'userDescription': 'December 2017'},
             '24fb3e68-4dca-46db-bf49-04b84e07e77c':
@@ -146,8 +109,10 @@ class TestSurveyMetadata(AppContextTestCase):
                  'longName': 'Business Register and '
                              'Employment Survey',
                  'shortName': 'BRES',
+                 'surveyType': 'Business',
                  'surveyId': 'cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87',
-                 'userDescription': 'January 2018'}}
+                 'userDescription': 'January 2018'},
+        }
 
         actual_result = map_collection_exercise_id_to_survey_id(
             map_surveys_to_collection_exercises(self.surveys_response, self.collection_exercises_response))
@@ -160,19 +125,8 @@ class TestSurveyMetadata(AppContextTestCase):
             self.assertEqual(e.survey_id, 'cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87')
 
     @responses.activate
-    def test_only_ready_collection_exercises_returned_after_filter(self):
-        with self.app.app_context():
-            # Mock the survey and collection exercise services
-            responses.add(
-                responses.GET,
-                self.app.config['SURVEY_URL'] + 'surveys',
-                json=self.surveys_response)
-            responses.add(
-                responses.GET,
-                self.app.config['COLLECTION_EXERCISE_URL'] + 'collectionexercises',
-                json=self.collection_exercises_response)
-
-            surveys, collection_exercises = fetch_survey_and_collection_exercise_metadata()
+    def test_only_ready_business_collection_exercises_returned_after_filter(self):
+        collection_exercises, surveys = self.fetch_mock_survey_and_collection_exercises_response()
 
         expected_surveys = [
             {
@@ -181,6 +135,7 @@ class TestSurveyMetadata(AppContextTestCase):
                 'collectionInstrumentType': 'seft',
                 'longName': 'Business Register and Employment Survey',
                 'surveyRef': '221',
+                'surveyType': 'Business',
                 'collectionExercises': [
                     {
                         'collectionExerciseId': '24fb3e68-4dca-46db-bf49-04b84e07e77c',
@@ -195,6 +150,7 @@ class TestSurveyMetadata(AppContextTestCase):
                 'collectionInstrumentType': 'seft',
                 'longName': 'Annual Outward Foreign Direct Investment Survey',
                 'surveyRef': '063',
+                'surveyType': 'Business',
                 'collectionExercises': []
             },
             {
@@ -203,6 +159,7 @@ class TestSurveyMetadata(AppContextTestCase):
                 'shortName': 'QBS',
                 'longName': 'Quarterly Business Survey',
                 'surveyRef': '064',
+                'surveyType': 'Business',
                 'collectionExercises': [
                     {
                         'collectionExerciseId': '14fb3e68-4dca-46db-bf49-04b84e07e777',
@@ -220,6 +177,7 @@ class TestSurveyMetadata(AppContextTestCase):
                  'longName': 'Quarterly Business '
                              'Survey',
                  'shortName': 'QBS',
+                 'surveyType': 'Business',
                  'surveyId': '04dbb407-4438-4f89-acc4-53445d753111',
                  'userDescription': 'Quarterly '
                                     'Business Survey'},
@@ -229,6 +187,7 @@ class TestSurveyMetadata(AppContextTestCase):
                  'longName': 'Business Register and '
                              'Employment Survey',
                  'shortName': 'BRES',
+                 'surveyType': 'Business',
                  'surveyId': 'cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87',
                  'userDescription': 'January 2018'}}
 
@@ -239,3 +198,29 @@ class TestSurveyMetadata(AppContextTestCase):
         self.assertEqual(expected_collection_exercises,
                          collection_exercises,
                          'Filtered and mapped collection exercises did not match expected result')
+
+    @responses.activate
+    def test_only_business_surveys_are_returned_by_fetch(self):
+        collection_exercises, surveys = self.fetch_mock_survey_and_collection_exercises_response()
+
+        for survey in surveys:
+            self.assertEqual(survey['surveyType'], 'Business')
+
+        for collection_exercise in collection_exercises.values():
+            self.assertEqual(collection_exercise['surveyType'], 'Business')
+
+    def fetch_mock_survey_and_collection_exercises_response(self):
+        # Requires @responses.activate
+        with self.app.app_context():
+            # Mock the survey and collection exercise services
+            responses.add(
+                responses.GET,
+                self.app.config['SURVEY_URL'] + 'surveys',
+                json=self.surveys_response)
+            responses.add(
+                responses.GET,
+                self.app.config['COLLECTION_EXERCISE_URL'] + 'collectionexercises',
+                json=self.collection_exercises_response)
+
+            surveys, collection_exercises = fetch_survey_and_collection_exercise_metadata()
+        return collection_exercises, surveys

--- a/tests/test_data/get_surveys_response.json
+++ b/tests/test_data/get_surveys_response.json
@@ -4,6 +4,7 @@
     "shortName": "BRES",
     "longName": "Business Register and Employment Survey",
     "surveyRef": "221",
+    "surveyType": "Business",
     "legalBasis": "Statistics of Trade Act 1947",
     "legalBasisRef": "STA1947"
   },
@@ -12,6 +13,7 @@
     "shortName": "AOFDI",
     "longName": "Annual Outward Foreign Direct Investment Survey",
     "surveyRef": "063",
+    "surveyType": "Business",
     "legalBasis": "Statistics of Trade Act 1947",
     "legalBasisRef": "STA1947"
   },
@@ -20,6 +22,16 @@
     "shortName": "QBS",
     "longName": "Quarterly Business Survey",
     "surveyRef": "064",
+    "surveyType": "Business",
+    "legalBasis": "Statistics of Trade Act 1947",
+    "legalBasisRef": "STA1947"
+  },
+  {
+    "id": "56dbb407-4438-4f89-acc4-53445d753111",
+    "shortName": "LMS",
+    "longName": "Labour Market Survey",
+    "surveyRef": "999",
+    "surveyType": "Social",
     "legalBasis": "Statistics of Trade Act 1947",
     "legalBasisRef": "STA1947"
   }


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Social surveys are not yet supported, we need to filter them out of the surveys lists sent to the UI otherwise we will show them in the menu

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
* Added filters to only pass through business surveys and collection exercises to the front end
* Updated existing tests with `surveyType` json key
* Added unit test

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
* Run docker dev locally
* Follow the README in [social test setup scripts in rm-tools](https://github.com/ONSdigital/rm-tools/tree/master/social-test-setup) to run `make setup-and-execute`. This will create and execute a social type collection exercise
* Run this app locally pointing at the docker dev services
* Navigate to the dashboard home
* No `OHS` social survey should be present on the menu, even though it now has a live collection exercise
# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/aWA4J2cf/52-filter-social-surveys-from-business-surveys
