### PR TITLE
Make external call server side

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# SDC Responses Dashboard API
-[![Build Status](https://api.travis-ci.org/ONSdigital/sdc-responses-dashboard-api.svg?branch=master)](https://travis-ci.org/ONSdigital/sdc-responses-dashboard-api)
-[![Codacy Badge](https://api.codacy.com/project/badge/Grade/7aaabdc5ce3a47e587d95f6e2243be82)](https://www.codacy.com/app/MebinAbraham/sdc-responses-dashboard-api?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=ONSdigital/sdc-responses-dashboard-api&amp;utm_campaign=Badge_Grade)
+# SDC Responses Dashboard
+[![Build Status](https://api.travis-ci.org/ONSdigital/sdc-responses-dashboard.svg?branch=master)](https://travis-ci.org/ONSdigital/sdc-responses-dashboard)
+[![Codacy Badge](https://api.codacy.com/project/badge/Grade/80ad95f7aaa9477da6aa8fd9aec40f52)](https://www.codacy.com/project/MebinAbraham/sdc-responses-dashboard/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=ONSdigital/sdc-responses-dashboard&amp;utm_campaign=Badge_Grade_Dashboard)
 
 ## Run the application
 

--- a/app/api/reporting.py
+++ b/app/api/reporting.py
@@ -1,0 +1,34 @@
+from flask import Blueprint, abort
+from requests import HTTPError
+from structlog import get_logger
+
+from app.controllers.reporting_controller import get_reporting_details
+from app.common.validators import parse_uuid
+
+reporting_blueprint = Blueprint(name='reporting', import_name=__name__)
+
+logger = get_logger()
+
+
+@reporting_blueprint.route('/reporting/<collection_instrument_type>/collection-exercise/<collex_id>', methods=['GET'])
+def reporting_details(collection_instrument_type, collex_id):
+
+    ci_types = {'eq', 'seft'}
+
+    collex_id = parse_uuid(collex_id)
+
+    if not collex_id:
+        logger.debug('Malformed collection exercise ID', invalid_id=collex_id)
+        abort(404, 'Malformed collection exercise ID')
+
+    if not collection_instrument_type.lower() in ci_types:
+        logger.debug('Invalid CI type', ci_type=collection_instrument_type)
+        abort(404, 'Invalid CI type')
+
+    try:
+        report = get_reporting_details(collection_instrument_type, collex_id)
+    except HTTPError:
+        logger.debug('Invalid Collection exercise id')
+        abort(404)
+
+    return report

--- a/app/common/survey_metadata.py
+++ b/app/common/survey_metadata.py
@@ -50,8 +50,7 @@ def map_surveys_to_collection_exercises(surveys, collection_exercises) -> list:
                 message = 'Reference to unknown survey id in collection exercise'
                 logger.error(message, collection_exercise_id=collection_exercise['id'])
                 raise UnknownSurveyError(
-                    message=message,
-                    survey_id=['surveyId'])
+                    message=message, survey_id=['surveyId'])
             else:
                 raise
 

--- a/app/common/validators.py
+++ b/app/common/validators.py
@@ -1,0 +1,10 @@
+import uuid
+
+
+def parse_uuid(uuid_string):
+
+    try:
+        # Check if data is in valid UUID format
+        return str(uuid.UUID(uuid_string))
+    except ValueError:
+        return False

--- a/app/controllers/reporting_controller.py
+++ b/app/controllers/reporting_controller.py
@@ -1,0 +1,16 @@
+import requests
+from flask import current_app, abort
+
+
+def get_reporting_details(collectioninstrumenttype, collex_id):
+
+    url = f'{current_app.config["REPORTING_URL"]}reporting-api/v1/response-dashboard' \
+          f'/{collectioninstrumenttype}/collection-exercise/{collex_id}'
+    try:
+        response = requests.get(url)
+    except requests.exceptions.ConnectionError:
+        abort(500)
+
+    response.raise_for_status()
+
+    return response.text

--- a/app/setup.py
+++ b/app/setup.py
@@ -36,9 +36,11 @@ def add_blueprints(app):
 
     from app.api.health import health_blueprint
     from app.views.dashboard import dashboard_blueprint
+    from app.api.reporting import reporting_blueprint
 
     app.register_blueprint(health_blueprint)
     app.register_blueprint(dashboard_blueprint)
+    app.register_blueprint(reporting_blueprint)
 
 
 def add_error_handlers(app):

--- a/app/static/assets/js/dashboard.js
+++ b/app/static/assets/js/dashboard.js
@@ -117,13 +117,13 @@ function displayCollectionInstrumentData(collectionInstrumentType, response) {
 }
 
 function callAPI(collexID = $("#collex-id").data("collex"), enableTimeout = true) {
-    const reportingURL = $("#collex-id").data("reporting-url");
+    const reportingURL = $("#collex-id").data("reporting-proxy-url");
     const reportingRefreshCycle = $("#collex-id").data("reporting-refresh-cycle");
     const collectionInstrumentType = $("#collex-id").data("collection-instrument-type");
 
     $.ajax({
         dataType: "json",
-        url: reportingURL + "reporting-api/v1/response-dashboard/" + collectionInstrumentType + "/collection-exercise/" + collexID
+        url: reportingURL + collectionInstrumentType + "/collection-exercise/" + collexID
     }).done((result) => {
 
         $("#error-reporting").hide();

--- a/app/static/assets/js/datatables.js
+++ b/app/static/assets/js/datatables.js
@@ -81,7 +81,7 @@ function loadCollexTableData(collexTable, id) {
 
     $("#collex-datatable tbody").on("click", "tr", function() {
         const id = collexTable.row(this).id();
-        const reportingURL = $("#collex-id").data("reporting-url");
+        const reportingURL = $("#collex-id").data("reporting-proxy-url");
 
         if (typeof id !== "undefined") {
             if (typeof reportingURL == "undefined") {

--- a/app/templates/reporting.html
+++ b/app/templates/reporting.html
@@ -12,7 +12,7 @@
 		<!-- Custom CSS -->
 		<link rel="stylesheet" href="{{ url_for('static', filename='assets/css/custom-reporting.css') }}">
 	</head>
-	<body id="collex-id" data-collex="{{ collex_id }}" data-collection-instrument-type="{{ collection_instrument_type }}" data-reporting-url="{{ reporting_url }}" data-reporting-refresh-cycle="{{ reporting_refresh_cycle }}" class="no-sidebar skin-black">
+	<body id="collex-id" data-collex="{{ collex_id }}" data-collection-instrument-type="{{ collection_instrument_type }}" data-reporting-proxy-url="{{ reporting_proxy_url }}" data-reporting-refresh-cycle="{{ reporting_refresh_cycle }}" class="no-sidebar skin-black">
 		<!-- sidebar-collapse -->
 		<div class="wrapper">
 			{% include 'partials/_header.html' %}

--- a/app/views/dashboard.py
+++ b/app/views/dashboard.py
@@ -27,7 +27,7 @@ def get_surveys():
 @dashboard_blueprint.route('/dashboard/collection-exercise/<collection_exercise_id>', methods=['GET'])
 def get_survey_details(collection_exercise_id):
     surveys_metadata, collection_exercise_metadata = fetch_survey_and_collection_exercise_metadata()
-
+    reporting_proxy_url = f'//{current_app.config["HOST"]}:{current_app.config["PORT"]}/reporting/'
     try:
         collection_exercise = collection_exercise_metadata[collection_exercise_id]
     except KeyError:
@@ -40,8 +40,8 @@ def get_survey_details(collection_exercise_id):
         collection_instrument_type=collection_exercise['collectionInstrumentType'],
         survey_short_name=collection_exercise['shortName'],
         survey_long_name=collection_exercise['longName'],
+        reporting_proxy_url=reporting_proxy_url,
         collection_exercise=collection_exercise['userDescription'],
-        reporting_url=current_app.config['REPORTING_URL'],
         reporting_refresh_cycle=int(current_app.config['REPORTING_REFRESH_CYCLE'])
     )
 

--- a/tests/app/api/test_reporting.py
+++ b/tests/app/api/test_reporting.py
@@ -1,0 +1,56 @@
+import json
+
+import responses
+from requests import HTTPError
+
+from app.api.reporting import reporting_details
+from tests.app import AppContextTestCase
+
+
+class TestReporting(AppContextTestCase):
+
+    reporting_response = {'metadata': {'collectionExerciseId': '14fb3e68-4dca-46db-bf49-04b84e07e999',
+                                       'timeUpdated': 1533895381.534031},
+                          'report': {'inProgress': 99, 'accountsCreated': 402, 'accountsEnrolled': 259,
+                                     'notStarted': 457, 'completed': 160, 'sampleSize': 716}}
+
+    @responses.activate
+    def test_reporting_details_success(self):
+        with self.app.app_context():
+            responses.add(responses.GET, self.app.config['REPORTING_URL'] + 'reporting-api/v1/response-dashboard'
+                                                                            '/seft/'
+                                                                            'collection-exercise'
+                                                                            '/14fb3e68-4dca-46db-bf49'
+                                                                            '-04b84e07e999',
+                                                                            json=self.reporting_response, status=200)
+
+            report = reporting_details('seft', '14fb3e68-4dca-46db-bf49-04b84e07e999')
+            decoded_report = json.loads(report)
+
+        self.assertEqual(decoded_report, self.reporting_response)
+
+    @responses.activate
+    def test_reporting_details_malformed_collex(self):
+
+        response = self.test_client.get('/reporting/eq/collection-exercise/0002133304032532504')
+        self.assertEqual(response.status_code, 404)
+        self.assertIn(b'Sorry, we could not find the page you were looking for.', response.data)
+
+    @responses.activate
+    def test_reporting_details_invalid_CI_type(self):
+
+        response = self.test_client.get('/reporting/SAFT/collection-exercise/14fb3e68-4dca-46db-bf49-04b84e07e999')
+        self.assertEqual(response.status_code, 404)
+        self.assertIn(b'Sorry, we could not find the page you were looking for.', response.data)
+
+    @responses.activate
+    def test_reporting_details_invalid_collex(self):
+        with self.app.app_context():
+            responses.add(responses.GET, self.app.config['REPORTING_URL'] + 'reporting-api/v1/response-dashboard'
+                                                                            '/seft/'
+                                                                            'collection-exercise'
+                                                                            '/14fb3e68-4dca-46db-bf49'
+                                                                            '-04b84e07e997',
+                                                                            status=404)
+        response = self.test_client.get('/reporting/seft/collection-exercise/14fb3e68-4dca-46db-bf49-04b84e07e997')
+        self.assertEqual(response.status_code, 404)

--- a/tests/app/common/test_validators.py
+++ b/tests/app/common/test_validators.py
@@ -1,0 +1,12 @@
+from app.common.validators import parse_uuid
+from tests.app import AppContextTestCase
+
+class TestValidators(AppContextTestCase):
+
+    def test_valid_uuid(self):
+        collex_id = parse_uuid('00000000-0000-00000000-000000000000')
+        self.assertTrue(collex_id)
+
+    def test_malformed_uuid(self):
+        collex_id = parse_uuid('this-is-not-a-valid-uuid')
+        self.assertFalse(collex_id)

--- a/tests/app/controllers/test_reporting_controller.py
+++ b/tests/app/controllers/test_reporting_controller.py
@@ -1,0 +1,30 @@
+import json
+
+import responses
+
+from app.controllers.reporting_controller import get_reporting_details
+from tests.app import AppContextTestCase
+
+
+class TestReportingController(AppContextTestCase):
+
+    reporting_response = {'metadata': {'collectionExerciseId': '14fb3e68-4dca-46db-bf49-04b84e07e999',
+                                       'timeUpdated': 1533895381.534031},
+                          'report': {'inProgress': 99, 'accountsCreated': 402, 'accountsEnrolled': 259,
+                                     'notStarted': 457, 'completed': 160, 'sampleSize': 716}}
+
+    @responses.activate
+    def test_get_reporting_details_success(self):
+        with self.app.app_context():
+            responses.add(responses.GET, self.app.config['REPORTING_URL'] + 'reporting-api/v1/response-dashboard'
+                                                                            '/seft/'
+                                                                            'collection-exercise'
+                                                                            '/14fb3e68-4dca-46db-bf49'
+                                                                            '-04b84e07e999',
+                                                                            json=self.reporting_response, status=200)
+
+            report = get_reporting_details('seft', '14fb3e68-4dca-46db-bf49-04b84e07e999')
+            decoded_report = json.loads(report)
+
+        self.assertEqual(decoded_report, self.reporting_response)
+


### PR DESCRIPTION
### Motivation and Context
The original call to RM-reporting needed be changed as it was a straight ajax request which we wouldn't be able to do when this is deployed later. Instead a new API was created to instead hit the reporting service at server side instead of client side.

### What has changed
- Added a API to RM-reporting
- Added appropriate tests

### How to test?
- Run make test and all tests should pass
- The dashboard should run correctly when started up.

### Links
[Trello Card](https://trello.com/c/UiN4ahJX/56-create-endpoints-to-allow-us-to-query-reporting-service-server-side)
