### PR TITLE
Altering route to dashboard

### DIFF
--- a/app/api/health.py
+++ b/app/api/health.py
@@ -4,6 +4,5 @@ health_blueprint = Blueprint(name='health', import_name=__name__)
 
 
 @health_blueprint.route('/health')
-@health_blueprint.route('/')
 def health():
     return jsonify({'status': 'healthy'})

--- a/app/static/assets/js/datatables.js
+++ b/app/static/assets/js/datatables.js
@@ -85,7 +85,7 @@ function loadCollexTableData(collexTable, id) {
 
         if (typeof id !== "undefined") {
             if (typeof reportingURL == "undefined") {
-                window.location.href = 'dashboard/collection-exercise/' + id;
+                window.location.href = 'collection-exercise/' + id;
             } else {
                 window.location.href = id;
             }

--- a/app/views/dashboard.py
+++ b/app/views/dashboard.py
@@ -14,7 +14,7 @@ def clear_trailing():
         return redirect(rp[:-1])
 
 
-@dashboard_blueprint.route('/dashboard', methods=['GET'])
+@dashboard_blueprint.route('/', methods=['GET'])
 def get_surveys():
     surveys_metadata, _ = fetch_survey_and_collection_exercise_metadata()
 
@@ -24,7 +24,7 @@ def get_surveys():
     )
 
 
-@dashboard_blueprint.route('/dashboard/collection-exercise/<collection_exercise_id>', methods=['GET'])
+@dashboard_blueprint.route('/collection-exercise/<collection_exercise_id>', methods=['GET'])
 def get_survey_details(collection_exercise_id):
     surveys_metadata, collection_exercise_metadata = fetch_survey_and_collection_exercise_metadata()
     reporting_proxy_url = f'//{current_app.config["HOST"]}:{current_app.config["PORT"]}/reporting/'

--- a/tests/app/errors/handlers/test_handlers.py
+++ b/tests/app/errors/handlers/test_handlers.py
@@ -21,7 +21,7 @@ class TestErrorHandlers(AppContextTestCase):
                 self.app.config['SURVEY_URL'] + 'surveys',
                 status=500)
 
-        response = self.test_client.get('/dashboard/collection-exercise/00000000-0000-0000-0000-000000000000')
+        response = self.test_client.get('/collection-exercise/00000000-0000-0000-0000-000000000000')
 
         self.assertEqual(response.status_code, 500)
         self.assertEqual(response.status, '500 INTERNAL SERVER ERROR')

--- a/tests/app/views/test_dashboard.py
+++ b/tests/app/views/test_dashboard.py
@@ -34,7 +34,7 @@ class TestSurveyController(AppContextTestCase):
     def test_dashboard_homepage(self):
         self.mock_successful_external_api_calls()
 
-        response = self.test_client.get('/dashboard')
+        response = self.test_client.get('/')
         self.assertEqual(response.status_code, 200)
         self.assertIn(b'Choose A Survey', response.data)
         self.assertIn(b'Survey', response.data)
@@ -48,7 +48,7 @@ class TestSurveyController(AppContextTestCase):
     def test_dashboard_report_fails_gracefully(self):
         self.mock_successful_external_api_calls()
 
-        response = self.test_client.get('/dashboard/collection-exercise/24fb3e68-4dca-46db-bf49-04b84e07e77c')
+        response = self.test_client.get('/collection-exercise/24fb3e68-4dca-46db-bf49-04b84e07e77c')
         self.assertEqual(response.status_code, 200)
         self.assertIn(b'BRES | January 2018', response.data)
         self.assertIn(b'Business Register and Employment Survey', response.data)
@@ -58,7 +58,7 @@ class TestSurveyController(AppContextTestCase):
     def test_dashboard_report_invalid_collex(self):
         self.mock_successful_external_api_calls()
 
-        response = self.test_client.get('/dashboard/collection-exercise/invalid-collex')
+        response = self.test_client.get('/collection-exercise/invalid-collex')
         self.assertEqual(response.status_code, 404)
         self.assertIn(b'Sorry, we could not find the page you were looking for.', response.data)
 
@@ -66,5 +66,5 @@ class TestSurveyController(AppContextTestCase):
     def test_dashboard_redirects_to_non_trailing_slash(self):
         self.mock_successful_external_api_calls()
 
-        response = self.test_client.get('/dashboard/')
+        response = self.test_client.get('/collection-exercise/24fb3e68-4dca-46db-bf49-04b84e07e77c/')
         self.assertEqual(response.status_code, 302)


### PR DESCRIPTION
# Motivation and Context
We have decided to change the route to the dashboard homepage so that the user would not have to add `/dashboard` onto the end of the url. Makes it more readable for when it gets deployed later on

# What has changed
- Changed dashboard route from `/dashboard` to `/`

# How to test?
- Go to the homepage using the url `localhost:5000` and the homepage should appear
- Check the navigation links redirect to the new route
# Links
[Trello card](https://trello.com/c/yioJLNre/62-change-routing-on-dashboard)
