### PR TITLE
Fixed error handling

### DIFF
--- a/app/errors/handlers.py
+++ b/app/errors/handlers.py
@@ -7,26 +7,22 @@ logger = get_logger()
 def not_found_error(error):
     custom_error_msg = 'Sorry, we could not find the page you were looking for.'
 
-    logger.error(error.name,
-                 error=error,
-                 status_code=error.code,
-                 description=error.description)
+    logger.error("Handling 404 error",
+                 error=error)
 
     return render_template('errors/error.html',
-                           status_code=error.code,
-                           error_name=error.name,
+                           status_code=404,
+                           error_name='Not found error',
                            error_msg=custom_error_msg), 404
 
 
 def internal_server_error(error):
     custom_error_msg = 'Sorry, something has gone wrong.'
 
-    logger.error(error.name,
-                 error=error,
-                 status_code=error.code,
-                 description=error.description)
+    logger.error("Handling 500 error",
+                 error=error)
 
     return render_template('errors/error.html',
-                           status_code=error.code,
-                           error_name=error.name,
+                           status_code=500,
+                           error_name='Internal server error',
                            error_msg=custom_error_msg), 500

--- a/tests/app/errors/handlers/test_handlers.py
+++ b/tests/app/errors/handlers/test_handlers.py
@@ -8,8 +8,7 @@ class TestErrorHandlers(AppContextTestCase):
     def test_not_found_error(self):
         response = self.test_client.get('/nonexistent-endpoint')
         self.assertEqual(response.status_code, 404)
-        self.assertEqual(response.status, '404 NOT FOUND')
-        self.assertIn(b'Not Found', response.data, )
+        self.assertIn(b'Oops! Not found error', response.data, )
         self.assertIn(b'Sorry, we could not find the page you were looking for.', response.data)
 
     @responses.activate
@@ -24,7 +23,6 @@ class TestErrorHandlers(AppContextTestCase):
         response = self.test_client.get('/collection-exercise/00000000-0000-0000-0000-000000000000')
 
         self.assertEqual(response.status_code, 500)
-        self.assertEqual(response.status, '500 INTERNAL SERVER ERROR')
-        self.assertIn(b'Internal Server Error', response.data, )
+        self.assertIn(b'Oops! Internal server error', response.data, )
         self.assertIn(b'Sorry, something has gone wrong.', response.data)
 


### PR DESCRIPTION
# Motivation and Context
When incorrect auth details where passed in, the error handling wasn't catching the 500 error and a default flask error page was appearing. This PR fixes that by changing the error handlers inside of the dashboard

# What has changed
- Fixed error handlers in the dashboard

# How to test?
Pass a incorrect `AUTH` variable and the a 500 error page should appear instead of a flask debug page.

# Links
[Trello card](https://trello.com/c/L8tkmvCJ/66-improve-graceful-error-handling)
