### PR TITLE
Fix logging format

### DIFF
--- a/app/api/reporting.py
+++ b/app/api/reporting.py
@@ -2,8 +2,8 @@ from flask import Blueprint, abort
 from requests import HTTPError
 from structlog import get_logger
 
-from app.controllers.reporting_controller import get_reporting_details
 from app.common.validators import parse_uuid
+from app.controllers.reporting_controller import get_reporting_details
 
 reporting_blueprint = Blueprint(name='reporting', import_name=__name__)
 

--- a/app/controllers/collection_exercise_controller.py
+++ b/app/controllers/collection_exercise_controller.py
@@ -1,8 +1,10 @@
-from flask import current_app, abort
 import requests
-from requests.auth import HTTPBasicAuth
 import requests.exceptions
+from flask import current_app, abort
+from requests.auth import HTTPBasicAuth
 from structlog import get_logger
+
+from app.exceptions import ApiConnectionError
 
 logger = get_logger()
 
@@ -16,8 +18,7 @@ def get_collection_exercise_list():
             auth=HTTPBasicAuth(current_app.config['AUTH_USERNAME'],
                                current_app.config['AUTH_PASSWORD']))
     except requests.exceptions.ConnectionError:
-        logger.error('Failed to connect to collection exercise service')
-        abort(500)
+        raise ApiConnectionError('Failed to connect to collection exercise service')
     if response.status_code != 200:
         logger.error('Failed to retrieve collection exercises',
                      status_code=response.status_code,

--- a/app/controllers/collection_exercise_controller.py
+++ b/app/controllers/collection_exercise_controller.py
@@ -4,7 +4,7 @@ from requests.auth import HTTPBasicAuth
 import requests.exceptions
 from structlog import get_logger
 
-from app.exceptions import ApiConnectionError
+from app.exceptions import APIConnectionError
 
 logger = get_logger()
 
@@ -18,7 +18,7 @@ def get_collection_exercise_list():
             auth=HTTPBasicAuth(current_app.config['AUTH_USERNAME'],
                                current_app.config['AUTH_PASSWORD']))
     except requests.exceptions.ConnectionError:
-        raise ApiConnectionError('Failed to connect to collection exercise service')
+        raise APIConnectionError('Failed to connect to collection exercise service')
     if response.status_code != 200:
         logger.error('Failed to retrieve collection exercises',
                      status_code=response.status_code,

--- a/app/controllers/collection_exercise_controller.py
+++ b/app/controllers/collection_exercise_controller.py
@@ -1,7 +1,7 @@
+from flask import current_app
 import requests
-import requests.exceptions
-from flask import current_app, abort
 from requests.auth import HTTPBasicAuth
+import requests.exceptions
 from structlog import get_logger
 
 from app.exceptions import ApiConnectionError

--- a/app/controllers/reporting_controller.py
+++ b/app/controllers/reporting_controller.py
@@ -2,7 +2,7 @@ from flask import current_app
 import requests
 from structlog import get_logger
 
-from app.exceptions import ApiConnectionError
+from app.exceptions import APIConnectionError
 
 logger = get_logger()
 
@@ -16,7 +16,7 @@ def get_reporting_details(collectioninstrumenttype, collex_id):
     try:
         response = requests.get(url)
     except requests.exceptions.ConnectionError:
-        raise ApiConnectionError('Failed to connect to reporting service')
+        raise APIConnectionError('Failed to connect to reporting service')
 
     response.raise_for_status()
 

--- a/app/controllers/reporting_controller.py
+++ b/app/controllers/reporting_controller.py
@@ -1,16 +1,26 @@
+from app.exceptions import ApiConnectionError
+
 import requests
-from flask import current_app, abort
+from flask import current_app
+from structlog import get_logger
+
+logger = get_logger()
 
 
 def get_reporting_details(collectioninstrumenttype, collex_id):
-
+    logger.debug('Fetching report for collection exercise',
+                 collex_id=collex_id,
+                 collection_instrument_type=collectioninstrumenttype)
     url = f'{current_app.config["REPORTING_URL"]}reporting-api/v1/response-dashboard' \
           f'/{collectioninstrumenttype}/collection-exercise/{collex_id}'
     try:
         response = requests.get(url)
     except requests.exceptions.ConnectionError:
-        abort(500)
+        raise ApiConnectionError('Failed to connect to reporting service')
 
     response.raise_for_status()
 
+    logger.debug('Successfully fetched report for collection exercise',
+                 collex_id=collex_id,
+                 collection_instrument_type=collectioninstrumenttype)
     return response.text

--- a/app/controllers/reporting_controller.py
+++ b/app/controllers/reporting_controller.py
@@ -1,8 +1,8 @@
-from app.exceptions import ApiConnectionError
-
-import requests
 from flask import current_app
+import requests
 from structlog import get_logger
+
+from app.exceptions import ApiConnectionError
 
 logger = get_logger()
 

--- a/app/controllers/survey_controller.py
+++ b/app/controllers/survey_controller.py
@@ -1,7 +1,7 @@
-from flask import current_app as app, abort
+from flask import current_app as app
 import requests
-import requests.exceptions
 from requests.auth import HTTPBasicAuth
+import requests.exceptions
 from structlog import get_logger
 
 from app.exceptions import ApiConnectionError

--- a/app/controllers/survey_controller.py
+++ b/app/controllers/survey_controller.py
@@ -4,7 +4,7 @@ from requests.auth import HTTPBasicAuth
 import requests.exceptions
 from structlog import get_logger
 
-from app.exceptions import ApiConnectionError
+from app.exceptions import APIConnectionError
 
 logger = get_logger()
 
@@ -18,7 +18,7 @@ def get_survey_list():
             auth=HTTPBasicAuth(app.config['AUTH_USERNAME'],
                                app.config['AUTH_PASSWORD']))
     except requests.exceptions.ConnectionError:
-        raise ApiConnectionError('Failed to connect to survey service')
+        raise APIConnectionError('Failed to connect to survey service')
 
     if response.status_code != 200:
         logger.error('Failed to retrieve surveys',

--- a/app/controllers/survey_controller.py
+++ b/app/controllers/survey_controller.py
@@ -4,6 +4,8 @@ import requests.exceptions
 from requests.auth import HTTPBasicAuth
 from structlog import get_logger
 
+from app.exceptions import ApiConnectionError
+
 logger = get_logger()
 
 
@@ -16,12 +18,13 @@ def get_survey_list():
             auth=HTTPBasicAuth(app.config['AUTH_USERNAME'],
                                app.config['AUTH_PASSWORD']))
     except requests.exceptions.ConnectionError:
-        logger.error('Failed to connect to survey service')
-        abort(500)
+        raise ApiConnectionError('Failed to connect to survey service')
+
     if response.status_code != 200:
         logger.error('Failed to retrieve surveys',
                      status_code=response.status_code,
                      response=response.content)
         response.raise_for_status()
+
     logger.debug('Successfully retrieved surveys')
     return response.json()

--- a/app/errors/handlers.py
+++ b/app/errors/handlers.py
@@ -1,28 +1,36 @@
 from structlog import get_logger
 from flask import render_template
 
+ERROR_MESSAGE_NOT_FOUND = 'Sorry, we could not find the page you were looking for.'
+ERROR_MESSAGE_UNEXPECTED = 'Sorry, something has gone wrong.'
+
 logger = get_logger()
 
 
 def not_found_error(error):
-    custom_error_msg = 'Sorry, we could not find the page you were looking for.'
-
-    logger.error("Handling 404 error",
+    logger.error('Handling 404 error',
                  error=error)
 
     return render_template('errors/error.html',
                            status_code=404,
                            error_name='Not found error',
-                           error_msg=custom_error_msg), 404
+                           error_msg=ERROR_MESSAGE_NOT_FOUND), 404
 
 
 def internal_server_error(error):
-    custom_error_msg = 'Sorry, something has gone wrong.'
-
-    logger.error("Handling 500 error",
+    logger.error('Handling 500 error',
                  error=error)
 
     return render_template('errors/error.html',
                            status_code=500,
                            error_name='Internal server error',
-                           error_msg=custom_error_msg), 500
+                           error_msg=ERROR_MESSAGE_UNEXPECTED), 500
+
+
+def api_connection_error(error):
+    logger.error(error.message)
+
+    return render_template('errors/error.html',
+                           status_code=500,
+                           error_name='Internal server error',
+                           error_msg=ERROR_MESSAGE_UNEXPECTED), 500

--- a/app/exceptions/__init__.py
+++ b/app/exceptions/__init__.py
@@ -1,3 +1,3 @@
-from app.exceptions.exceptions import UnknownSurveyError, MissingConfigError
+from app.exceptions.exceptions import UnknownSurveyError, MissingConfigError, ApiConnectionError
 
-__all__ = ['UnknownSurveyError', 'MissingConfigError']
+__all__ = ['UnknownSurveyError', 'MissingConfigError', 'ApiConnectionError']

--- a/app/exceptions/__init__.py
+++ b/app/exceptions/__init__.py
@@ -1,3 +1,3 @@
-from app.exceptions.exceptions import UnknownSurveyError, MissingConfigError, ApiConnectionError
+from app.exceptions.exceptions import UnknownSurveyError, MissingConfigError, APIConnectionError
 
-__all__ = ['UnknownSurveyError', 'MissingConfigError', 'ApiConnectionError']
+__all__ = ['UnknownSurveyError', 'MissingConfigError', 'APIConnectionError']

--- a/app/exceptions/exceptions.py
+++ b/app/exceptions/exceptions.py
@@ -13,8 +13,8 @@ class MissingConfigError(Exception):
         self.keys = keys
 
 
-class ApiConnectionError(Exception):
+class APIConnectionError(Exception):
 
     def __init__(self, message):
-        super(ApiConnectionError, self).__init__(message)
+        super(APIConnectionError, self).__init__(message)
         self.message = message

--- a/app/exceptions/exceptions.py
+++ b/app/exceptions/exceptions.py
@@ -11,3 +11,10 @@ class MissingConfigError(Exception):
     def __init__(self, keys: set):
         super(MissingConfigError, self).__init__(keys)
         self.keys = keys
+
+
+class ApiConnectionError(Exception):
+
+    def __init__(self, message):
+        super(ApiConnectionError, self).__init__(message)
+        self.message = message

--- a/app/setup.py
+++ b/app/setup.py
@@ -2,18 +2,18 @@ import logging
 import os
 import sys
 
-import structlog
 from flask import Flask
 from flask_cors import CORS
+import structlog
 from structlog import wrap_logger
 from structlog.processors import JSONRenderer
 from structlog.processors import TimeStamper, format_exc_info
 from structlog.stdlib import add_log_level, add_logger_name, filter_by_level, LoggerFactory
 from structlog.threadlocal import wrap_dict
 
-import config
 from app.errors.handlers import api_connection_error
 from app.exceptions import MissingConfigError, ApiConnectionError
+import config
 
 
 def create_app():

--- a/app/setup.py
+++ b/app/setup.py
@@ -12,7 +12,7 @@ from structlog.stdlib import add_log_level, add_logger_name, filter_by_level, Lo
 from structlog.threadlocal import wrap_dict
 
 from app.errors.handlers import api_connection_error
-from app.exceptions import MissingConfigError, ApiConnectionError
+from app.exceptions import MissingConfigError, APIConnectionError
 import config
 
 
@@ -56,7 +56,7 @@ def add_error_handlers(app):
 
     app.register_error_handler(404, not_found_error)
     app.register_error_handler(500, internal_server_error)
-    app.register_error_handler(ApiConnectionError, api_connection_error)
+    app.register_error_handler(APIConnectionError, api_connection_error)
 
 
 def _configure_logger(level='INFO', indent=None):

--- a/config.py
+++ b/config.py
@@ -24,7 +24,7 @@ class Config:
     AUTH_USERNAME = os.getenv('AUTH_USERNAME')
     AUTH_PASSWORD = os.getenv('AUTH_PASSWORD')
     LOGGING_LEVEL = os.getenv('LOGGING_LEVEL', 'INFO')
-    LOGGING_JSON_INDENT = os.getenv('LOGGING_JSON_INDENT', '0')
+    LOGGING_JSON_INDENT = os.getenv('LOGGING_JSON_INDENT')
 
 
 class DevelopmentConfig(Config):
@@ -38,6 +38,7 @@ class DevelopmentConfig(Config):
     REPORTING_REFRESH_CYCLE = os.getenv('REPORTING_REFRESH_CYCLE', '10000')
     AUTH_USERNAME = os.getenv('AUTH_USERNAME', 'admin')
     AUTH_PASSWORD = os.getenv('AUTH_PASSWORD', 'secret')
+    LOGGING_LEVEL = os.getenv('LOGGING_LEVEL', 'DEBUG')
     LOGGING_JSON_INDENT = os.getenv('LOGGING_JSON_INDENT', '4')
 
 


### PR DESCRIPTION
# Motivation and Context
The logging for the service needs to be changed as it will clog up splunk with the current json format. Also the controllers were using the flask abort function to exit on an error, this PR adds a custom error for api connection problems and a flask handler to render the correct page.

# What has changed
- Adding logging format to setup.py
- Added `ApiConnectionError` exception
- Added `ApiConnectionError` exception flask handler
- Changed controllers to raise `ApiConnectionError` if on connection errors
- Added debug logging to the reporting controller
- Log the log level when the logger is created at app start

# How to test?
- Create an error and see what format error comes out as
- Run the dashboard and check if it runs correctly

# Links
[Trello](https://trello.com/c/NuMsAZyI/68-fix-logging-on-cf-environment)
