### PR TITLE
Add basic auth to reporting service API call

### DIFF
--- a/app/controllers/reporting_controller.py
+++ b/app/controllers/reporting_controller.py
@@ -1,5 +1,6 @@
 from flask import current_app
 import requests
+from requests.auth import HTTPBasicAuth
 from structlog import get_logger
 
 from app.exceptions import APIConnectionError
@@ -14,7 +15,9 @@ def get_reporting_details(collectioninstrumenttype, collex_id):
     url = f'{current_app.config["REPORTING_URL"]}reporting-api/v1/response-dashboard' \
           f'/{collectioninstrumenttype}/collection-exercise/{collex_id}'
     try:
-        response = requests.get(url)
+        response = requests.get(url,
+                                auth=HTTPBasicAuth(current_app.config['AUTH_USERNAME'],
+                                                   current_app.config['AUTH_PASSWORD']))
     except requests.exceptions.ConnectionError:
         raise APIConnectionError('Failed to connect to reporting service')
 


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The reporting service may need basic auth on API calls in other environments, this PR adds the basic auth to the reporting service call.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
* Added basic auth to reporting service call

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Run locally against the ci-latest space urls with the ci-latest auth set, the reporting service should still return numbers as expected.