### PR TITLE
Stop logging errors on 404

### DIFF
--- a/app/errors/handlers.py
+++ b/app/errors/handlers.py
@@ -7,7 +7,9 @@ ERROR_MESSAGE_UNEXPECTED = 'Sorry, something has gone wrong.'
 logger = get_logger()
 
 
-def not_found_error(_):
+def not_found_error(error):
+    logger.debug('Handling 404 error',
+                 error=error)
     return render_template('errors/error.html',
                            status_code=404,
                            error_name='Not found error',

--- a/app/errors/handlers.py
+++ b/app/errors/handlers.py
@@ -7,10 +7,7 @@ ERROR_MESSAGE_UNEXPECTED = 'Sorry, something has gone wrong.'
 logger = get_logger()
 
 
-def not_found_error(error):
-    logger.error('Handling 404 error',
-                 error=error)
-
+def not_found_error(_):
     return render_template('errors/error.html',
                            status_code=404,
                            error_name='Not found error',


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Currently the app logs at error level every time it handles a 404. 404's are not necessarily and application error and do not need to be logged at error level, debug is sufficient.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
* Changed the error logging from the 404 handler to debug

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Start the app and go to a non existent route while tailing the logs. You should see the 404 page but no error log for a 404 response.