### PR TITLE
Add default value for user description

### DIFF
--- a/app/static/assets/js/datatables.js
+++ b/app/static/assets/js/datatables.js
@@ -38,6 +38,7 @@ function initiliseDataTables() {
         data: [],
         columns: [{
             "data": "userDescription",
+            "defaultContent": "No description provided",
             "title": "Collection Exercise Period",
             "width": "600px"
         }],
@@ -71,6 +72,9 @@ function initiliseDataTables() {
 }
 
 function loadCollexTableData(collexTable, id) {
+    /**
+     *  Load the collection exercise data into the data table
+     */
 
     const surveys = JSON.parse($('#collex-id').data('surveys'));
 
@@ -80,8 +84,8 @@ function loadCollexTableData(collexTable, id) {
     $("#modal-collex").modal("toggle");
 
     $("#collex-datatable tbody").on("click", "tr", function() {
-        const id = collexTable.row(this).id();
-        collexID = $("#collex-id").data("collex")
+        let id = collexTable.row(this).id();
+        let collexID = $("#collex-id").data("collex")
 
         if (typeof id !== "undefined") {
             if (typeof collexID == "undefined") {
@@ -95,10 +99,21 @@ function loadCollexTableData(collexTable, id) {
 }
 
 function getCollexFromSurveyId(surveys, survey_id) {
+    /**
+     *  Returns an array of collection exercises for a given survey id
+     */
 
     for (let i = 0; i < surveys.length; i++) {
         if (surveys[i].surveyId === survey_id) {
             let collectionExercises = surveys[i].collectionExercises;
+            let surveyShortName = surveys[i].shortName;
+
+            for (let collex in collectionExercises) {
+                if (collectionExercises[collex].userDescription === "" ) {
+                    collectionExercises[collex].userDescription = 'No description provided'
+                }
+            }
+
             return collectionExercises;
         }
     }

--- a/app/templates/partials/_content_header.html
+++ b/app/templates/partials/_content_header.html
@@ -1,6 +1,6 @@
 <section class="content-header">
     <h1 id="survey-short-name">
-        {{ survey_short_name }} {{ " | " ~  collection_exercise_description if collection_exercise_description }}
+        {{ survey_short_name }}{{ " | " ~  collection_exercise_description if collection_exercise_description }}
     </h1>
     <ol class="breadcrumb">
         <li>

--- a/app/templates/partials/_content_header.html
+++ b/app/templates/partials/_content_header.html
@@ -1,15 +1,13 @@
 <section class="content-header">
-    {% if survey_short_name and collection_exercise %}
-        <h1 id="survey-short-name">
-            {{ survey_short_name ~ " | " ~ collection_exercise }}
-        </h1>
-    {% endif %}
+    <h1 id="survey-short-name">
+        {{ survey_short_name }} {{ " | " ~  collection_exercise_description if collection_exercise_description }}
+    </h1>
     <ol class="breadcrumb">
         <li>
             <a href="{{ url_for('dashboard.get_surveys') }}">
             <i class="fa fa-dashboard"></i> Dashboard</a>
         </li>
-        {% if survey_long_name and collection_exercise %}
+        {% if survey_long_name %}
             <li>
                 <a href="#">Survey</a>
             </li>

--- a/app/views/dashboard.py
+++ b/app/views/dashboard.py
@@ -39,7 +39,7 @@ def get_survey_details(collection_exercise_id):
         collection_instrument_type=collection_exercise['collectionInstrumentType'],
         survey_short_name=collection_exercise['shortName'],
         survey_long_name=collection_exercise['longName'],
-        collection_exercise=collection_exercise['userDescription'],
+        collection_exercise_description=collection_exercise['userDescription'],
         reporting_refresh_cycle=int(current_app.config['REPORTING_REFRESH_CYCLE'])
     )
 

--- a/tests/app/views/test_dashboard.py
+++ b/tests/app/views/test_dashboard.py
@@ -1,5 +1,6 @@
 import json
 import os
+from pprint import pprint
 
 import responses
 
@@ -68,3 +69,48 @@ class TestSurveyController(AppContextTestCase):
 
         response = self.test_client.get('/dashboard/collection-exercise/24fb3e68-4dca-46db-bf49-04b84e07e77c/')
         self.assertEqual(response.status_code, 302)
+
+    @responses.activate
+    def test_dashboard_still_shows_survey_short_name_when_description_is_missing(self):
+        collex_response_missing_description = self.collex_response.copy()
+        collex_response_missing_description[0]['userDescription'] = None
+        pprint(collex_response_missing_description)
+        with self.app.app_context():
+
+            responses.add(
+                responses.GET,
+                self.app.config['SURVEY_URL'] + 'surveys',
+                json=self.surveys_response,
+                status=200)
+
+            responses.add(
+                responses.GET,
+                self.app.config['COLLECTION_EXERCISE_URL'] + 'collectionexercises',
+                json=collex_response_missing_description,
+                status=200)
+
+        response = self.test_client.get('/dashboard/collection-exercise/24fb3e68-4dca-46db-bf49-04b84e07e77c')
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b'BRES', response.data)
+
+    @responses.activate
+    def test_dashboard_still_shows_survey_short_name_when_description_is_empty(self):
+        collex_response_missing_description = self.collex_response.copy()
+        collex_response_missing_description[1]['userDescription'] = ''
+        with self.app.app_context():
+            responses.add(
+                responses.GET,
+                self.app.config['SURVEY_URL'] + 'surveys',
+                json=self.surveys_response,
+                status=200)
+
+            responses.add(
+                responses.GET,
+                self.app.config['COLLECTION_EXERCISE_URL'] + 'collectionexercises',
+                json=collex_response_missing_description,
+                status=200)
+
+        response = self.test_client.get('/dashboard/collection-exercise/24fb3e68-4dca-46db-bf49-04b84e07e77c')
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b'BRES', response.data)
+


### PR DESCRIPTION
# Motivation and Context
Adds a default value for user description when it is empty.

# What has changed
Datatable now gets a default value for `defaultContent` which display this value when the data is either `null` or `undefined`.

Added a check to also have the same behaviour if the string is empty.

# How to test?
- Ensure app works as expected.
- Default value provided for collection exercise period on modal (userDescription) if empty etc. -> remove userDescription from mock services to test.