### PR TITLE
Remove trailing slash from url variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ make mock_services
 
 And set these environment variables for the dashboard app:
 ```.dotenv
-COLLECTION_EXERCISE_URL=http://localhost:5001/
-SURVEY_URL=http://localhost:5001/
-REPORTING_URL=http://localhost:5001/
+COLLECTION_EXERCISE_URL=http://localhost:5001
+SURVEY_URL=http://localhost:5001
+REPORTING_URL=http://localhost:5001
 ```
 
 ## Testing and Linting

--- a/app/controllers/collection_exercise_controller.py
+++ b/app/controllers/collection_exercise_controller.py
@@ -10,7 +10,7 @@ logger = get_logger()
 
 
 def get_collection_exercise_list():
-    url = f'{current_app.config["COLLECTION_EXERCISE_URL"]}collectionexercises'
+    url = f'{current_app.config["COLLECTION_EXERCISE_URL"]}/collectionexercises'
     logger.debug('Attempting to retrieve collection exercises')
     try:
         response = requests.get(

--- a/app/controllers/reporting_controller.py
+++ b/app/controllers/reporting_controller.py
@@ -11,7 +11,7 @@ def get_reporting_details(collection_instrument_type, collex_id):
     logger.debug('Fetching report for collection exercise',
                  collex_id=collex_id,
                  collection_instrument_type=collection_instrument_type)
-    url = f'{current_app.config["REPORTING_URL"]}reporting-api/v1/response-dashboard' \
+    url = f'{current_app.config["REPORTING_URL"]}/reporting-api/v1/response-dashboard' \
           f'/{collection_instrument_type}/collection-exercise/{collex_id}'
     try:
         response = requests.get(url)

--- a/app/controllers/survey_controller.py
+++ b/app/controllers/survey_controller.py
@@ -10,7 +10,7 @@ logger = get_logger()
 
 
 def get_survey_list():
-    url = f'{app.config["SURVEY_URL"]}surveys'
+    url = f'{app.config["SURVEY_URL"]}/surveys'
     logger.debug('Attempting to retrieve surveys')
     try:
         response = requests.get(

--- a/config.py
+++ b/config.py
@@ -32,9 +32,9 @@ class DevelopmentConfig(Config):
     PORT = os.getenv('PORT', '5000')
     HOST = os.getenv('HOST', 'localhost')
     ENV = os.getenv('FLASK_ENV', 'development')
-    COLLECTION_EXERCISE_URL = os.getenv('COLLECTION_EXERCISE_URL', 'http://localhost:8145/')
-    SURVEY_URL = os.getenv('SURVEY_URL', 'http://localhost:8080/')
-    REPORTING_URL = os.getenv('REPORTING_URL', 'http://localhost:8084/')
+    COLLECTION_EXERCISE_URL = os.getenv('COLLECTION_EXERCISE_URL', 'http://localhost:8145')
+    SURVEY_URL = os.getenv('SURVEY_URL', 'http://localhost:8080')
+    REPORTING_URL = os.getenv('REPORTING_URL', 'http://localhost:8084')
     REPORTING_REFRESH_CYCLE = os.getenv('REPORTING_REFRESH_CYCLE', '10000')
     AUTH_USERNAME = os.getenv('AUTH_USERNAME', 'admin')
     AUTH_PASSWORD = os.getenv('AUTH_PASSWORD', 'secret')
@@ -43,7 +43,7 @@ class DevelopmentConfig(Config):
 
 
 class TestingConfig(Config):
-    testing_url = 'http://test/'
+    testing_url = 'http://test'
     COLLECTION_EXERCISE_URL = testing_url
     SURVEY_URL = testing_url
     REPORTING_URL = testing_url

--- a/tests/app/api/test_reporting.py
+++ b/tests/app/api/test_reporting.py
@@ -17,7 +17,7 @@ class TestReporting(AppContextTestCase):
     @responses.activate
     def test_reporting_details_success(self):
         with self.app.app_context():
-            responses.add(responses.GET, self.app.config['REPORTING_URL'] + 'reporting-api/v1/response-dashboard'
+            responses.add(responses.GET, self.app.config['REPORTING_URL'] + '/reporting-api/v1/response-dashboard'
                                                                             '/seft/'
                                                                             'collection-exercise'
                                                                             '/14fb3e68-4dca-46db-bf49'
@@ -46,7 +46,7 @@ class TestReporting(AppContextTestCase):
     @responses.activate
     def test_reporting_details_invalid_collex(self):
         with self.app.app_context():
-            responses.add(responses.GET, self.app.config['REPORTING_URL'] + 'reporting-api/v1/response-dashboard'
+            responses.add(responses.GET, self.app.config['REPORTING_URL'] + '/reporting-api/v1/response-dashboard'
                                                                             '/seft/'
                                                                             'collection-exercise'
                                                                             '/14fb3e68-4dca-46db-bf49'

--- a/tests/app/controllers/test_collection_exercise_controller.py
+++ b/tests/app/controllers/test_collection_exercise_controller.py
@@ -19,7 +19,7 @@ class TestSurveyController(AppContextTestCase):
         with self.app.app_context():
             responses.add(
                 responses.GET,
-                self.app.config['COLLECTION_EXERCISE_URL'] + 'collectionexercises',
+                self.app.config['COLLECTION_EXERCISE_URL'] + '/collectionexercises',
                 json=self.collection_exercises_response,
                 status=200)
 
@@ -32,7 +32,7 @@ class TestSurveyController(AppContextTestCase):
         with self.app.app_context():
             responses.add(
                 responses.GET,
-                self.app.config['COLLECTION_EXERCISE_URL'] + 'collectionexercises',
+                self.app.config['COLLECTION_EXERCISE_URL'] + '/collectionexercises',
                 status=401)
 
             with self.assertRaises(HTTPError):

--- a/tests/app/controllers/test_reporting_controller.py
+++ b/tests/app/controllers/test_reporting_controller.py
@@ -16,7 +16,7 @@ class TestReportingController(AppContextTestCase):
     @responses.activate
     def test_get_reporting_details_success(self):
         with self.app.app_context():
-            responses.add(responses.GET, self.app.config['REPORTING_URL'] + 'reporting-api/v1/response-dashboard'
+            responses.add(responses.GET, self.app.config['REPORTING_URL'] + '/reporting-api/v1/response-dashboard'
                                                                             '/seft/'
                                                                             'collection-exercise'
                                                                             '/14fb3e68-4dca-46db-bf49'

--- a/tests/app/controllers/test_survey_controller.py
+++ b/tests/app/controllers/test_survey_controller.py
@@ -19,7 +19,7 @@ class TestSurveyController(AppContextTestCase):
         with self.app.app_context():
             responses.add(
                 responses.GET,
-                self.app.config['SURVEY_URL'] + 'surveys',
+                self.app.config['SURVEY_URL'] + '/surveys',
                 json=self.surveys_response,
                 status=200)
 
@@ -32,7 +32,7 @@ class TestSurveyController(AppContextTestCase):
         with self.app.app_context():
             responses.add(
                 responses.GET,
-                self.app.config['SURVEY_URL'] + 'surveys',
+                self.app.config['SURVEY_URL'] + '/surveys',
                 status=401)
 
             with self.assertRaises(HTTPError):

--- a/tests/app/errors/handlers/test_handlers.py
+++ b/tests/app/errors/handlers/test_handlers.py
@@ -17,7 +17,7 @@ class TestErrorHandlers(AppContextTestCase):
         with self.app.app_context():
             responses.add(
                 responses.GET,
-                self.app.config['SURVEY_URL'] + 'surveys',
+                self.app.config['SURVEY_URL'] + '/surveys',
                 status=500)
 
         response = self.test_client.get('/dashboard/collection-exercise/00000000-0000-0000-0000-000000000000')

--- a/tests/app/test_survey_metadata.py
+++ b/tests/app/test_survey_metadata.py
@@ -238,11 +238,11 @@ class TestSurveyMetadata(AppContextTestCase):
             # Mock the survey and collection exercise services
             responses.add(
                 responses.GET,
-                self.app.config['SURVEY_URL'] + 'surveys',
+                self.app.config['SURVEY_URL'] + '/surveys',
                 json=self.surveys_response)
             responses.add(
                 responses.GET,
-                self.app.config['COLLECTION_EXERCISE_URL'] + 'collectionexercises',
+                self.app.config['COLLECTION_EXERCISE_URL'] + '/collectionexercises',
                 json=self.collection_exercises_response)
 
             surveys, collection_exercises = fetch_survey_and_collection_exercise_metadata()

--- a/tests/app/views/test_dashboard.py
+++ b/tests/app/views/test_dashboard.py
@@ -21,13 +21,13 @@ class TestSurveyController(AppContextTestCase):
 
             responses.add(
                 responses.GET,
-                self.app.config['SURVEY_URL'] + 'surveys',
+                self.app.config['SURVEY_URL'] + '/surveys',
                 json=self.surveys_response,
                 status=200)
 
             responses.add(
                 responses.GET,
-                self.app.config['COLLECTION_EXERCISE_URL'] + 'collectionexercises',
+                self.app.config['COLLECTION_EXERCISE_URL'] + '/collectionexercises',
                 json=self.collex_response,
                 status=200)
 
@@ -79,13 +79,13 @@ class TestSurveyController(AppContextTestCase):
 
             responses.add(
                 responses.GET,
-                self.app.config['SURVEY_URL'] + 'surveys',
+                self.app.config['SURVEY_URL'] + '/surveys',
                 json=self.surveys_response,
                 status=200)
 
             responses.add(
                 responses.GET,
-                self.app.config['COLLECTION_EXERCISE_URL'] + 'collectionexercises',
+                self.app.config['COLLECTION_EXERCISE_URL'] + '/collectionexercises',
                 json=collex_response_missing_description,
                 status=200)
 
@@ -100,13 +100,13 @@ class TestSurveyController(AppContextTestCase):
         with self.app.app_context():
             responses.add(
                 responses.GET,
-                self.app.config['SURVEY_URL'] + 'surveys',
+                self.app.config['SURVEY_URL'] + '/surveys',
                 json=self.surveys_response,
                 status=200)
 
             responses.add(
                 responses.GET,
-                self.app.config['COLLECTION_EXERCISE_URL'] + 'collectionexercises',
+                self.app.config['COLLECTION_EXERCISE_URL'] + '/collectionexercises',
                 json=collex_response_missing_description,
                 status=200)
 


### PR DESCRIPTION
# Motivation and Context
The URL's in the config required a trailing slash to function. This has been bugging me.

# What has changed
Removed the trailing slash from the environment variable urls

# How to test?
Check the app still functions correctly and properly calls all the services it depends on.

# Links
https://trello.com/c/PLb8qrLi/77-remove-trailing-slashes-from-config-urls

Updated pipline ready to be flown:
https://github.com/ONSdigital/ras-deploy/pull/72
