### PR TITLE
Change accounts created to accounts pending

### DIFF
--- a/app/static/assets/js/dashboard.js
+++ b/app/static/assets/js/dashboard.js
@@ -94,7 +94,7 @@ function displayCollectionInstrumentData(collectionInstrumentType, response) {
     for (let figure in report) {
         if (report.hasOwnProperty(figure)) {
 
-            layoutClass = Object.keys(report).length % 2 && figure === "sampleSize" ? "col-lg-12 col-xs-12" : "col-lg-6 col-xs-12";
+            layoutClass = Object.keys(report).length % 2 && figure === "sampleSize" ? "col-lg-12 col-xs-12" : "col-lg-6 col-sm-6 col-xs-12";
 
             $("#counters").append($("<div>", {
                 "class": layoutClass

--- a/app/static/assets/js/dashboard.js
+++ b/app/static/assets/js/dashboard.js
@@ -13,6 +13,12 @@ function getReportSEFT(response) {
             "value": response.report.uploads,
             "class": "fa fa-upload"
         },
+         "accountsPending": {
+            "id": "accounts-pending",
+            "title": "Accounts Pending",
+            "value": response.report.accountsPending,
+            "class": "fa fa-user-plus"
+        },
         "accountsEnrolled": {
             "id": "accounts-enrolled",
             "title": "Accounts Enrolled",
@@ -87,8 +93,11 @@ function displayCollectionInstrumentData(collectionInstrumentType, response) {
     /* eslint-disable */
     for (let figure in report) {
         if (report.hasOwnProperty(figure)) {
+
+            layoutClass = Object.keys(report).length % 2 && figure === "sampleSize" ? "col-lg-12 col-xs-12" : "col-lg-6 col-xs-12";
+
             $("#counters").append($("<div>", {
-                "class": "col-lg-6 col-xs-6"
+                "class": layoutClass
             }).append($("<div>", {
                 "class": "small-box bg-ons-light-blue",
                 "id": report[figure].id + "-box"

--- a/app/static/assets/js/dashboard.js
+++ b/app/static/assets/js/dashboard.js
@@ -32,10 +32,10 @@ function getReportSEFT(response) {
 
 function getReportEQ(response) {
     const report = {
-        "accountsCreated": {
-            "id": "accounts-created",
-            "title": "Accounts Created",
-            "value": response.report.accountsCreated,
+        "accountsPending": {
+            "id": "accounts-pending",
+            "title": "Accounts Pending",
+            "value": response.report.accountsPending,
             "class": "fa fa-user-plus"
         },
         "accountsEnrolled": {

--- a/scripts/mock_services.py
+++ b/scripts/mock_services.py
@@ -31,6 +31,7 @@ def get_report(collection_instrument_type, collection_exercise_id):
             'report': {
                 'downloads': downloads,
                 'uploads': uploads,
+                'accountsPending': accounts_pending,
                 'accountsEnrolled': accounts_pending,
                 'sampleSize': sample_size
             }

--- a/scripts/mock_services.py
+++ b/scripts/mock_services.py
@@ -17,10 +17,10 @@ def get_report(collection_instrument_type, collection_exercise_id):
     rand_gen = SystemRandom()
 
     sample_size = rand_gen.randint(100, 1000)
-    accounts_created = rand_gen.randint(0, sample_size)
-    downloads = rand_gen.randint(0, accounts_created)
+    accounts_pending = rand_gen.randint(0, sample_size)
+    downloads = rand_gen.randint(0, accounts_pending)
     uploads = rand_gen.randint(0, downloads)
-    accounts_enrolled = rand_gen.randint(uploads, accounts_created)
+    accounts_enrolled = rand_gen.randint(uploads, accounts_pending)
 
     if collection_instrument_type.lower() == 'seft':
         response = {
@@ -31,7 +31,7 @@ def get_report(collection_instrument_type, collection_exercise_id):
             'report': {
                 'downloads': downloads,
                 'uploads': uploads,
-                'accountsEnrolled': accounts_created,
+                'accountsEnrolled': accounts_pending,
                 'sampleSize': sample_size
             }
         }
@@ -43,7 +43,7 @@ def get_report(collection_instrument_type, collection_exercise_id):
             },
             'report': {
                 'inProgress': downloads - uploads,
-                'accountsCreated': accounts_created,
+                'accountsPending': accounts_pending,
                 'accountsEnrolled': accounts_enrolled,
                 'notStarted': sample_size - downloads,
                 'completed': uploads,

--- a/scripts/mock_services.py
+++ b/scripts/mock_services.py
@@ -32,7 +32,7 @@ def get_report(collection_instrument_type, collection_exercise_id):
                 'downloads': downloads,
                 'uploads': uploads,
                 'accountsPending': accounts_pending,
-                'accountsEnrolled': accounts_pending,
+                'accountsEnrolled': accounts_enrolled,
                 'sampleSize': sample_size
             }
         }

--- a/tests/app/api/test_reporting.py
+++ b/tests/app/api/test_reporting.py
@@ -18,13 +18,13 @@ class TestReporting(AppContextTestCase):
     def test_reporting_details_success(self):
         with self.app.app_context():
             responses.add(responses.GET, self.app.config['REPORTING_URL'] + '/reporting-api/v1/response-dashboard'
-                                                                            '/seft/'
+                                                                            '/eq/'
                                                                             'collection-exercise'
                                                                             '/14fb3e68-4dca-46db-bf49'
                                                                             '-04b84e07e999',
                                                                             json=self.reporting_response, status=200)
 
-            report = reporting_details('seft', '14fb3e68-4dca-46db-bf49-04b84e07e999')
+            report = reporting_details('eq', '14fb3e68-4dca-46db-bf49-04b84e07e999')
             decoded_report = json.loads(report)
 
         self.assertEqual(decoded_report, self.reporting_response)

--- a/tests/app/api/test_reporting.py
+++ b/tests/app/api/test_reporting.py
@@ -11,7 +11,7 @@ class TestReporting(AppContextTestCase):
 
     reporting_response = {'metadata': {'collectionExerciseId': '14fb3e68-4dca-46db-bf49-04b84e07e999',
                                        'timeUpdated': 1533895381.534031},
-                          'report': {'inProgress': 99, 'accountsCreated': 402, 'accountsEnrolled': 259,
+                          'report': {'inProgress': 99, 'accountsPending': 402, 'accountsEnrolled': 259,
                                      'notStarted': 457, 'completed': 160, 'sampleSize': 716}}
 
     @responses.activate

--- a/tests/app/controllers/test_reporting_controller.py
+++ b/tests/app/controllers/test_reporting_controller.py
@@ -10,7 +10,7 @@ class TestReportingController(AppContextTestCase):
 
     reporting_response = {'metadata': {'collectionExerciseId': '14fb3e68-4dca-46db-bf49-04b84e07e999',
                                        'timeUpdated': 1533895381.534031},
-                          'report': {'inProgress': 99, 'accountsCreated': 402, 'accountsEnrolled': 259,
+                          'report': {'inProgress': 99, 'accountsPending': 402, 'accountsEnrolled': 259,
                                      'notStarted': 457, 'completed': 160, 'sampleSize': 716}}
 
     @responses.activate

--- a/tests/app/views/test_dashboard.py
+++ b/tests/app/views/test_dashboard.py
@@ -1,13 +1,12 @@
 import json
 import os
-from pprint import pprint
 
 import responses
 
 from tests.app import AppContextTestCase
 
 
-class TestSurveyController(AppContextTestCase):
+class TestDashboardView(AppContextTestCase):
     current_file_path = os.path.dirname(__file__)
 
     with open(os.path.join(current_file_path, '../../test_data/get_surveys_response.json')) as fp:
@@ -74,7 +73,6 @@ class TestSurveyController(AppContextTestCase):
     def test_dashboard_still_shows_survey_short_name_when_description_is_missing(self):
         collex_response_missing_description = self.collex_response.copy()
         collex_response_missing_description[0]['userDescription'] = None
-        pprint(collex_response_missing_description)
         with self.app.app_context():
 
             responses.add(


### PR DESCRIPTION
# Motivation and Context
We decided 'Accounts Created' is now a misleading title since the figure only counts accounts currently in the 'Pending' state. This PR matches changes we have in reporting service to rename the field. Also adds accounts pending to the seft dashboard since this figure was already on the EQ version.
# What has changed
* Renamed all instances of 'account created' to 'accounts pending'
* Add 'Accounts Pending' to seft dashboard

# How to test?
Run with the change branch of RM reporting, the dashboard should still function correctly and now show 'Accounts Pending' instead of 'Accounts Created' on EQ collection exercises.

# Links
https://trello.com/c/m2WueDTM/78-investigating-how-to-fix-the-query-based-on-the-recent-bi-case-changes
https://github.com/ONSdigital/rm-reporting/pull/14