### PR TITLE
Version static assets

### DIFF
--- a/app/setup.py
+++ b/app/setup.py
@@ -1,7 +1,6 @@
 import logging
 import os
 import sys
-import time
 
 from flask import Flask, url_for, current_app
 from flask_cors import CORS

--- a/app/setup.py
+++ b/app/setup.py
@@ -1,8 +1,9 @@
 import logging
 import os
 import sys
+import time
 
-from flask import Flask
+from flask import Flask, url_for
 from flask_cors import CORS
 import structlog
 from structlog import wrap_logger
@@ -36,6 +37,10 @@ def create_app():
     add_blueprints(app)
     add_error_handlers(app)
 
+    @app.context_processor
+    def override_url_for():  # pylint: disable=unused-variable
+        return dict(url_for=versioned_url_for)
+
     return app
 
 
@@ -57,6 +62,17 @@ def add_error_handlers(app):
     app.register_error_handler(404, not_found_error)
     app.register_error_handler(500, internal_server_error)
     app.register_error_handler(APIConnectionError, api_connection_error)
+
+
+def versioned_url_for(endpoint, **values):
+
+    if endpoint == 'static':
+        filename = values.get('filename', None)
+        if filename:
+            values['filename'] = filename
+            values['q'] = int(time.time()) if os.getenv('APP_SETTINGS') == 'DevelopmentConfig' else '1.0.0'
+
+    return url_for(endpoint, **values)
 
 
 def _configure_logger(level='INFO', indent=None):

--- a/app/setup.py
+++ b/app/setup.py
@@ -3,7 +3,7 @@ import os
 import sys
 import time
 
-from flask import Flask, url_for
+from flask import Flask, url_for, current_app
 from flask_cors import CORS
 import structlog
 from structlog import wrap_logger
@@ -70,7 +70,7 @@ def versioned_url_for(endpoint, **values):
         filename = values.get('filename', None)
         if filename:
             values['filename'] = filename
-            values['q'] = int(time.time()) if os.getenv('APP_SETTINGS') == 'DevelopmentConfig' else '1.0.0'
+            values['q'] = current_app.config['STATIC_ASSETS_VERSION']
 
     return url_for(endpoint, **values)
 

--- a/config.py
+++ b/config.py
@@ -1,4 +1,3 @@
-from distutils.util import strtobool
 import os
 
 REQUIRED_ENVIRONMENT_VARIABLES = {

--- a/config.py
+++ b/config.py
@@ -57,3 +57,4 @@ class TestingConfig(Config):
     REPORTING_REFRESH_CYCLE = '10000'
     AUTH_USERNAME = 'admin'
     AUTH_PASSWORD = 'secret'
+    STATIC_ASSETS_VERSION = 'test'

--- a/config.py
+++ b/config.py
@@ -1,4 +1,5 @@
 import os
+import time
 
 REQUIRED_ENVIRONMENT_VARIABLES = {
     'PORT',
@@ -8,7 +9,8 @@ REQUIRED_ENVIRONMENT_VARIABLES = {
     'REPORTING_URL',
     'REPORTING_REFRESH_CYCLE',
     'AUTH_USERNAME',
-    'AUTH_PASSWORD'
+    'AUTH_PASSWORD',
+    'STATIC_ASSETS_VERSION'
 }
 
 
@@ -24,6 +26,7 @@ class Config:
     AUTH_PASSWORD = os.getenv('AUTH_PASSWORD')
     LOGGING_LEVEL = os.getenv('LOGGING_LEVEL', 'INFO')
     LOGGING_JSON_INDENT = os.getenv('LOGGING_JSON_INDENT')
+    STATIC_ASSETS_VERSION = os.getenv('STATIC_ASSETS_VERSION', '1.0.0')  # Defaulted until releases
 
 
 class DevelopmentConfig(Config):
@@ -39,6 +42,7 @@ class DevelopmentConfig(Config):
     AUTH_PASSWORD = os.getenv('AUTH_PASSWORD', 'secret')
     LOGGING_LEVEL = os.getenv('LOGGING_LEVEL', 'DEBUG')
     LOGGING_JSON_INDENT = os.getenv('LOGGING_JSON_INDENT', '4')
+    STATIC_ASSETS_VERSION = os.getenv('STATIC_ASSETS_VERSION', str(int(time.time())))
 
 
 class TestingConfig(Config):


### PR DESCRIPTION
### Motivation and Context
This adds a query string to any app assets so that the assets are cache controlled.
For Development, the query string is just appended with `time.time()`, feel free to suggest something else.

For production, once any changes to app css/js is made, we need to bump the version up!.
An alternative is to have an app config such as `STATIC_ASSETS_VERSION`.

### What has changed
Added a processor to add a query to assests.
A request with the same query string is cached, but once it changes, it is treated as a new file, hence it will get a fresh copy instead of getting a copy from cache.
Before: 
`<script src="/dashboard/static/assets/js/datatables.js"></script>`

After: 
`<script src="/dashboard/static/assets/js/datatables.js?q=1.0.0"></script>`

### How to test?
- Make any changes locally and ensure the change is refelected in the browser without having to manually clear cache.

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
