### PR TITLE
Fix styling issue with height of collex modal

### DIFF
--- a/app/static/assets/css/custom-reporting.css
+++ b/app/static/assets/css/custom-reporting.css
@@ -200,3 +200,8 @@ div.dataTables_wrapper div.dataTables_paginate {
 		transform: scale(1.0);
 	}
 }
+
+#collex-datatable td {
+    max-width: 70px;
+    overflow: hidden;
+}

--- a/app/static/assets/js/datatables.js
+++ b/app/static/assets/js/datatables.js
@@ -8,7 +8,7 @@ function initialiseDataTables() {
         info: true,
         autoWidth: false,
         autoHeight: false,
-        scrollY: "30vh",
+        scrollY: "35vh",
         scrollCollapse: true,
         scroller: {
             loadingIndicator: false
@@ -24,7 +24,7 @@ function initialiseDataTables() {
         if (type === "sort" || type === "type") {
             return data;
         } else {
-            return moment(data).format("DD-MM-YYYY");  // eslint-disable-line no-undef
+            return moment(data).format("DD-MM-YYYY"); // eslint-disable-line no-undef
         }
     };
 
@@ -37,33 +37,35 @@ function initialiseDataTables() {
         info: true,
         autoWidth: false,
         autoHeight: false,
-        scrollY: "30vh",
+        scrollY: "35vh",
         scrollCollapse: true,
         scroller: {
-            loadingIndicator: false
+            loadingIndicator: false,
+            rowHeight: 40
         },
         data: [],
         order: [
-            [1, 'desc'], [2, 'desc']
+            [1, 'desc'],
+            [2, 'desc']
         ],
         columns: [{
                 "data": "userDescription",
                 "defaultContent": "No description provided",
                 "title": "Collection Exercise Period",
-                "width": "300px"
+                "width": "50%"
             },
             {
                 "data": "periodStartDateTime",
                 "defaultContent": "No start date provided",
                 "title": "Start Date",
-                "width": "300px",
+                "width": "25%",
                 "render": dateRender
             },
             {
                 "data": "periodEndDateTime",
                 "defaultContent": "No end date provided",
                 "title": "End Date",
-                "width": "300px",
+                "width": "25%",
                 "render": dateRender
             }
         ],
@@ -108,6 +110,19 @@ function loadCollexTableData(collexTable, id) {
 
     $("#modal-collex").modal("toggle");
 
+    // Dynamically set scroller rowHeight
+    let checkCollexTableExist = setInterval(function() {
+        let height = $("#collex-datatable tbody").height();
+        if (height) {
+            // sets the height of next div which follows the collex-datatable element
+            $("#collex-datatable + div").height(height + 1);
+            // sets the width of the headers to 100%
+            $(".dataTables_scrollHeadInner table").css("width", "100%");
+            clearInterval(checkCollexTableExist);
+        }
+    }, 100);
+
+
     $("#collex-datatable tbody").on("click", "tr", function() {
         let id = collexTable.row(this).id();
         let collexID = $("#collex-id").data("collex");
@@ -134,7 +149,7 @@ function getCollexFromSurveyId(surveys, survey_id) {
 
             for (let collex in collectionExercises) {
                 if (collectionExercises[collex].userDescription === "") {
-                    collectionExercises[collex].userDescription = "No description provided";  // eslint-disable-line
+                    collectionExercises[collex].userDescription = "No description provided"; // eslint-disable-line
                 }
             }
 

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -8,7 +8,7 @@
 		<meta content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" name="viewport">
 		{% include 'partials/_styles.html' %}
 		<!-- DataTables -->
-		<link rel="stylesheet" href="https://cdn.datatables.net/1.10.18/css/dataTables.bootstrap.min.css">
+		<link rel="stylesheet" href="https://cdn.datatables.net/1.10.19/css/dataTables.bootstrap.min.css">
 		<!-- Custom CSS -->
 		<link rel="stylesheet" href="{{ url_for('static', filename='assets/css/custom-reporting.css') }}">
 		<link rel="stylesheet" href="{{ url_for('static', filename='assets/css/custom-dashboard.css') }}">
@@ -32,9 +32,9 @@
 		<!-- Moment JS -->
 		<script src="//cdnjs.cloudflare.com/ajax/libs/moment.js/2.8.4/moment.min.js"></script>
 		<!-- DataTables -->
-		<script src="https://cdn.datatables.net/1.10.18/js/jquery.dataTables.min.js"></script>
-		<script src="https://cdn.datatables.net/1.10.18/js/dataTables.bootstrap.min.js"></script>
-		<script src="https://cdn.datatables.net/scroller/1.4.4/js/dataTables.scroller.min.js"></script>
+		<script src="https://cdn.datatables.net/1.10.19/js/jquery.dataTables.min.js"></script>
+		<script src="https://cdn.datatables.net/1.10.19/js/dataTables.bootstrap.min.js"></script>
+		<script src="https://cdn.datatables.net/scroller/1.5.1/js/dataTables.scroller.min.js"></script>
 		<!-- App -->
 		<script src="{{ url_for('static', filename='assets/js/datatables.js') }}"></script>
 		<script>

--- a/app/templates/partials/_modal_collex.html
+++ b/app/templates/partials/_modal_collex.html
@@ -24,7 +24,10 @@
                     <div id="collex_modal_wrapper" class="dataTables_wrapper form-inline dt-bootstrap">
                         <div class="row">
                             <div class="col-sm-12">
-                                <table id="collex-datatable" class="table table-bordered table-striped dataTable table-cell-border table-datatable-hover" role="grid" aria-describedby="surveys" style="clear:both;">
+                                <table id="collex-datatable" class="table table-bordered table-striped dataTable table-cell-border table-datatable-hover" role="grid" aria-describedby="surveys" style="clear:both; height: auto !important;">
+                                <col style="width: 50%;" />
+                                <col style="width: 25%;" />
+                                <col style="width: 25%;" />
                                 </table>
                             </div>
                         </div>

--- a/app/templates/reporting.html
+++ b/app/templates/reporting.html
@@ -8,7 +8,7 @@
 		<meta content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" name="viewport">
 		{% include 'partials/_styles.html' %}
 		<!-- DataTables -->
-		<link rel="stylesheet" href="https://cdn.datatables.net/1.10.18/css/dataTables.bootstrap.min.css" />
+		<link rel="stylesheet" href="https://cdn.datatables.net/1.10.19/css/dataTables.bootstrap.min.css" />
 		<!-- Custom CSS -->
 		<link rel="stylesheet" href="{{ url_for('static', filename='assets/css/custom-reporting.css') }}" />
         <script src="https://cdnjs.cloudflare.com/ajax/libs/pace/1.0.2/pace.js"></script>
@@ -99,9 +99,9 @@
 		<!-- Moment JS -->
 		<script src="//cdnjs.cloudflare.com/ajax/libs/moment.js/2.8.4/moment.min.js"></script>
 		<!-- DataTables -->
-		<script src="https://cdn.datatables.net/1.10.18/js/jquery.dataTables.min.js"></script>
-		<script src="https://cdn.datatables.net/1.10.18/js/dataTables.bootstrap.min.js"></script>
-		<script src="https://cdn.datatables.net/scroller/1.4.4/js/dataTables.scroller.min.js"></script>
+		<script src="https://cdn.datatables.net/1.10.19/js/jquery.dataTables.min.js"></script>
+		<script src="https://cdn.datatables.net/1.10.19/js/dataTables.bootstrap.min.js"></script>
+		<script src="https://cdn.datatables.net/scroller/1.5.1/js/dataTables.scroller.min.js"></script>
 		<!-- App -->
 		<script src="{{ url_for('static', filename='assets/js/dashboard.js') }}"></script>
 		<script src="{{ url_for('static', filename='assets/js/datatables.js') }}"></script>


### PR DESCRIPTION
### Motivation and Context
Added a bit of functionality to dynamically set the height of the collex table as the scroller plugin expects the data to conform to the same height.

### What has changed
Added JS function to adjust height
Upgraded version of plugins
Some additional CSS for data control

### How to test?
Ensure on the collex modal, the height is as expected when text wraps to multiple lines.
Make sure to clear cache.