### PR TITLE
Update dashboard to pass survey ID to revised reporting endpoint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,3 @@
-dist: trusty
-sudo: true
-language: node_js
-node_js: 11
-
 cache:
     - yarn
     - pip
@@ -10,15 +5,29 @@ cache:
         - /opt/python/
         - /home/travis/.local/share/
 
-# command to install dependencies
-install:
-    - pip install --user -U pip pipenv
-    - pipenv install --dev
+matrix:
+  include:
+    - language: python
+      sudo: true
+      python:
+        - 3.6
+      # command to install dependencies
+      install:
+      - pip install -U pip pipenv
+      - pipenv install --dev
+      script:
+      - make test
+      branches:
+        only:
+        - master
 
-script:
-  - yarn compile
-  - make test
-
-branches:
-  only:
-    - master
+    - language: node_js
+      dist: trusty
+      sudo: true
+      node_js:
+        - 11
+      script:
+      - yarn compile
+      branches:
+        only:
+        - master

--- a/app/api/reporting.py
+++ b/app/api/reporting.py
@@ -18,10 +18,14 @@ logger = get_logger()
 def reporting_details(collection_instrument_type, survey_id, collex_id):
     ci_types = {'eq', 'seft'}
 
-    collex_id = parse_uuid(collex_id)
+    parsed_survey_id = parse_uuid(survey_id)
+    if not parsed_survey_id:
+        logger.debug('Malformed collection exercise ID', invalid_survey_id=survey_id)
+        abort(404, 'Malformed collection exercise ID')
 
-    if not collex_id:
-        logger.debug('Malformed collection exercise ID', invalid_id=collex_id)
+    parsed_collex_id = parse_uuid(collex_id)
+    if not parsed_collex_id:
+        logger.debug('Malformed collection exercise ID', invalid_collex_id=collex_id)
         abort(404, 'Malformed collection exercise ID')
 
     if not collection_instrument_type.lower() in ci_types:
@@ -29,9 +33,9 @@ def reporting_details(collection_instrument_type, survey_id, collex_id):
         abort(404, 'Invalid CI type')
 
     try:
-        report = get_reporting_details(survey_id, collex_id)
+        report = get_reporting_details(parsed_survey_id, parsed_collex_id)
     except HTTPError:
-        logger.debug('Invalid Collection exercise id')
+        logger.debug('Invalid collection exercise or survey id')
         abort(404)
 
     if collection_instrument_type == 'seft':

--- a/app/api/reporting.py
+++ b/app/api/reporting.py
@@ -1,18 +1,21 @@
+import json
+
 from flask import Blueprint, abort
 from requests import HTTPError
 from structlog import get_logger
 
-from app.validators import parse_uuid
 from app.controllers.reporting_controller import get_reporting_details
+from app.validators import parse_uuid
 
 reporting_blueprint = Blueprint(name='reporting', import_name=__name__, url_prefix='/dashboard')
 
 logger = get_logger()
 
 
-@reporting_blueprint.route('/reporting/<collection_instrument_type>/collection-exercise/<collex_id>', methods=['GET'])
-def reporting_details(collection_instrument_type, collex_id):
-
+@reporting_blueprint.route('/reporting/<collection_instrument_type>'
+                           '/survey/<survey_id>'
+                           '/collection-exercise/<collex_id>', methods=['GET'])
+def reporting_details(collection_instrument_type, survey_id, collex_id):
     ci_types = {'eq', 'seft'}
 
     collex_id = parse_uuid(collex_id)
@@ -26,9 +29,13 @@ def reporting_details(collection_instrument_type, collex_id):
         abort(404, 'Invalid CI type')
 
     try:
-        report = get_reporting_details(collection_instrument_type, collex_id)
+        report = get_reporting_details(survey_id, collex_id)
     except HTTPError:
         logger.debug('Invalid Collection exercise id')
         abort(404)
 
-    return report
+    if collection_instrument_type == 'seft':
+        report['report']['uploads'] = report['report'].pop('completed')
+        report['report']['downloads'] = report['report'].pop('inProgress') + report['report']['uploads']
+
+    return json.dumps(report)

--- a/app/controllers/reporting_controller.py
+++ b/app/controllers/reporting_controller.py
@@ -10,7 +10,7 @@ logger = get_logger()
 def get_reporting_details(survey_id, collex_id):
     logger.debug('Fetching report for collection exercise',
                  collex_id=collex_id,
-                 collection_instrument_type=survey_id)
+                 survey_id=survey_id)
     url = f'{current_app.config["REPORTING_URL"]}/reporting-api/v1/response-dashboard' \
           f'/survey/{survey_id}/collection-exercise/{collex_id}'
     try:

--- a/app/controllers/reporting_controller.py
+++ b/app/controllers/reporting_controller.py
@@ -1,5 +1,5 @@
-from flask import current_app
 import requests
+from flask import current_app
 from structlog import get_logger
 
 from app.exceptions import APIConnectionError
@@ -7,12 +7,12 @@ from app.exceptions import APIConnectionError
 logger = get_logger()
 
 
-def get_reporting_details(collection_instrument_type, collex_id):
+def get_reporting_details(survey_id, collex_id):
     logger.debug('Fetching report for collection exercise',
                  collex_id=collex_id,
-                 collection_instrument_type=collection_instrument_type)
+                 collection_instrument_type=survey_id)
     url = f'{current_app.config["REPORTING_URL"]}/reporting-api/v1/response-dashboard' \
-          f'/{collection_instrument_type}/collection-exercise/{collex_id}'
+          f'/survey/{survey_id}/collection-exercise/{collex_id}'
     try:
         response = requests.get(url)
     except requests.exceptions.ConnectionError:
@@ -22,5 +22,5 @@ def get_reporting_details(collection_instrument_type, collex_id):
 
     logger.debug('Successfully fetched report for collection exercise',
                  collex_id=collex_id,
-                 collection_instrument_type=collection_instrument_type)
-    return response.text
+                 survey_id=survey_id)
+    return response.json()

--- a/app/static/assets/js/datatables.js
+++ b/app/static/assets/js/datatables.js
@@ -3,6 +3,28 @@ function setDataTableHeaderWidth() {
 	$(".dataTables_scrollHeadInner table").css("width", "100%");
 }
 
+
+function setCollexTableHeight() {
+    // Dynamically set scroller rowHeight
+	let checkCollexTableExist = setInterval(function () {
+		let height = $("#collex-datatable tbody").height();
+		if (height) {
+			// sets the height of next div which follows the collex-datatable element
+			$("#collex-datatable + div").height(height + 1);
+			// sets the width of the headers to 100%
+			setDataTableHeaderWidth();
+			clearInterval(checkCollexTableExist);
+		}
+	}, 100);
+}
+
+function setDataTableDimension() {
+
+    setCollexTableHeight();
+    setDataTableHeaderWidth();
+
+}
+
 function initialiseDataTables() {
 	/* eslint-disable */
 	const surveyTable = $("#survey-datatable").DataTable({
@@ -116,7 +138,6 @@ function loadCollexTableData(collexTable, id) {
 	collexTable.rows.add(getCollexFromSurveyId(surveys, id)).draw();
 
 	$("#modal-collex").modal("toggle");
-
 	// Dynamically set scroller rowHeight
 	let checkCollexTableExist = setInterval(function () {
 		let height = $("#collex-datatable tbody").height();
@@ -128,7 +149,6 @@ function loadCollexTableData(collexTable, id) {
 			clearInterval(checkCollexTableExist);
 		}
 	}, 100);
-
 
 	$("#collex-datatable tbody").on("click", "tr", function () {
 		let id = collexTable.row(this).id();

--- a/app/static/assets/js/reporting.js
+++ b/app/static/assets/js/reporting.js
@@ -126,12 +126,13 @@ function displayCollectionInstrumentData(collectionInstrumentType, response) {
 
 function callAPI() {
     const collexID = $("#collex-id").data("collex");
+    const surveyID = $("#collex-id").data("survey");
     const reportingRefreshCycleInSeconds = $("#collex-id").data("reporting-refresh-cycle");
     const collectionInstrumentType = $("#collex-id").data("collection-instrument-type");
 
     $.ajax({
         dataType: "json",
-        url: `/dashboard/reporting/${collectionInstrumentType}/collection-exercise/${collexID}`
+        url: `/dashboard/reporting/${collectionInstrumentType}/survey/${surveyID}/collection-exercise/${collexID}`
     }).done((result) => {
 
         $(".content-header").show();

--- a/app/templates/reporting.html
+++ b/app/templates/reporting.html
@@ -14,7 +14,7 @@
         <script src="https://cdnjs.cloudflare.com/ajax/libs/pace/1.0.2/pace.min.js"></script>
         <link href="https://cdnjs.cloudflare.com/ajax/libs/pace/1.0.2/themes/blue/pace-theme-flash.min.css" rel="stylesheet" />
 	</head>
-	<body id="collex-id" data-collex="{{ collex_id }}" data-collection-instrument-type="{{ collection_instrument_type }}" data-reporting-refresh-cycle="{{ reporting_refresh_cycle }}" class="no-sidebar skin-black">
+	<body id="collex-id" data-survey="{{ survey_id }}" data-collex="{{ collex_id }}" data-collection-instrument-type="{{ collection_instrument_type }}" data-reporting-refresh-cycle="{{ reporting_refresh_cycle }}" class="no-sidebar skin-black">
 		<div class="wrapper">
 			{% include 'partials/_header.html' %}
 			<!-- Content Wrapper. Contains page content -->

--- a/app/views/dashboard.py
+++ b/app/views/dashboard.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, render_template, current_app, abort
+from flask import Blueprint, abort, current_app, render_template
 
 from app.survey_metadata import fetch_survey_and_collection_exercise_metadata
 
@@ -39,6 +39,7 @@ def get_survey_details(collection_exercise_id):
         collection_instrument_type=collection_exercise['collectionInstrumentType'],
         survey_short_name=collection_exercise['shortName'],
         survey_long_name=collection_exercise['longName'],
+        survey_id=collection_exercise['surveyId'],
         collection_exercise_description=collection_exercise['userDescription'],
         reporting_refresh_cycle=int(current_app.config['REPORTING_REFRESH_CYCLE_IN_SECONDS'])
     )

--- a/app/views/dashboard.py
+++ b/app/views/dashboard.py
@@ -25,7 +25,7 @@ def get_surveys():
 
 
 @dashboard_blueprint.route('/collection-exercise/<collection_exercise_id>', methods=['GET'])
-def get_survey_details(collection_exercise_id):
+def get_dashboard_for_collection_exercise(collection_exercise_id):
     surveys_metadata, collection_exercise_metadata = fetch_survey_and_collection_exercise_metadata()
     try:
         collection_exercise = collection_exercise_metadata[collection_exercise_id]

--- a/scripts/mock_services.py
+++ b/scripts/mock_services.py
@@ -1,8 +1,8 @@
-from datetime import datetime
 import json
+from datetime import datetime
 from random import SystemRandom
 
-from flask import Response, Flask
+from flask import Flask, Response
 from flask_cors import CORS
 
 app = Flask(__name__)
@@ -11,9 +11,9 @@ CORS(app)
 
 
 @app.route(
-    '/reporting-api/v1/response-dashboard/<collection_instrument_type>/collection-exercise/<collection_exercise_id>',
+    '/reporting-api/v1/response-dashboard/survey/<survey_id>/collection-exercise/<collection_exercise_id>',
     methods=['GET'])
-def get_report(collection_instrument_type, collection_exercise_id):
+def get_report(survey_id, collection_exercise_id):
     rand_gen = SystemRandom()
 
     sample_size = rand_gen.randint(100, 1000)
@@ -22,35 +22,20 @@ def get_report(collection_instrument_type, collection_exercise_id):
     uploads = rand_gen.randint(0, downloads)
     accounts_enrolled = rand_gen.randint(uploads, accounts_pending)
 
-    if collection_instrument_type.lower() == 'seft':
-        response = {
-            'metadata': {
-                'collectionExerciseId': collection_exercise_id,
-                'timeUpdated': datetime.now().timestamp()
-            },
-            'report': {
-                'downloads': downloads,
-                'uploads': uploads,
-                'accountsPending': accounts_pending,
-                'accountsEnrolled': accounts_enrolled,
-                'sampleSize': sample_size
-            }
+    response = {
+        'metadata': {
+            'collectionExerciseId': collection_exercise_id,
+            'timeUpdated': datetime.now().timestamp()
+        },
+        'report': {
+            'inProgress': downloads - uploads,
+            'accountsPending': accounts_pending,
+            'accountsEnrolled': accounts_enrolled,
+            'notStarted': sample_size - downloads,
+            'completed': uploads,
+            'sampleSize': sample_size
         }
-    else:
-        response = {
-            'metadata': {
-                'collectionExerciseId': collection_exercise_id,
-                'timeUpdated': datetime.now().timestamp()
-            },
-            'report': {
-                'inProgress': downloads - uploads,
-                'accountsPending': accounts_pending,
-                'accountsEnrolled': accounts_enrolled,
-                'notStarted': sample_size - downloads,
-                'completed': uploads,
-                'sampleSize': sample_size
-            }
-        }
+    }
 
     return Response(json.dumps(response), content_type='application/json')
 

--- a/tests/app/api/test_reporting.py
+++ b/tests/app/api/test_reporting.py
@@ -50,15 +50,20 @@ class TestReporting(AppContextTestCase):
 
         self.assertEqual(decoded_report, seft_reporting_response)
 
-    @responses.activate
-    def test_reporting_details_malformed_collex(self):
+    def test_reporting_details_malformed_collex_id(self):
         response = self.test_client.get('/dashboard/reporting/eq'
                                         '/survey/57586798-74e3-49fd-93da-a782ec5f5129'
-                                        '/collection-exercise/0002133304032532504')
+                                        '/collection-exercise/not-a-valid-uuid-format')
         self.assertEqual(response.status_code, 404)
         self.assertIn(b'Sorry, we could not find the page you were looking for.', response.data)
 
-    @responses.activate
+    def test_reporting_details_malformed_survey_id(self):
+        response = self.test_client.get('/dashboard/reporting/eq'
+                                        '/survey/not-a-valid-uuid-format'
+                                        '/collection-exercise/14fb3e68-4dca-46db-bf49-04b84e07e999')
+        self.assertEqual(response.status_code, 404)
+        self.assertIn(b'Sorry, we could not find the page you were looking for.', response.data)
+
     def test_reporting_details_invalid_CI_type(self):
         response = self.test_client.get('/dashboard/reporting/SAFT'
                                         '/survey/57586798-74e3-49fd-93da-a782ec5f5129'

--- a/tests/app/api/test_reporting.py
+++ b/tests/app/api/test_reporting.py
@@ -1,45 +1,68 @@
 import json
 
 import responses
-from requests import HTTPError
 
 from app.api.reporting import reporting_details
 from tests.app import AppContextTestCase
 
 
 class TestReporting(AppContextTestCase):
-
     reporting_response = {'metadata': {'collectionExerciseId': '14fb3e68-4dca-46db-bf49-04b84e07e999',
                                        'timeUpdated': 1533895381.534031},
                           'report': {'inProgress': 99, 'accountsPending': 402, 'accountsEnrolled': 259,
                                      'notStarted': 457, 'completed': 160, 'sampleSize': 716}}
 
     @responses.activate
-    def test_reporting_details_success(self):
+    def test_reporting_details_eq_success(self):
         with self.app.app_context():
             responses.add(responses.GET, self.app.config['REPORTING_URL'] + '/reporting-api/v1/response-dashboard'
-                                                                            '/eq/'
-                                                                            'collection-exercise'
-                                                                            '/14fb3e68-4dca-46db-bf49'
-                                                                            '-04b84e07e999',
-                                                                            json=self.reporting_response, status=200)
+                                                                            '/survey'
+                                                                            '/57586798-74e3-49fd-93da-a782ec5f5129'
+                                                                            '/collection-exercise'
+                                                                            '/14fb3e68-4dca-46db-bf49-04b84e07e999',
+                          json=self.reporting_response, status=200)
 
-            report = reporting_details('eq', '14fb3e68-4dca-46db-bf49-04b84e07e999')
+            report = reporting_details('eq',
+                                       '57586798-74e3-49fd-93da-a782ec5f5129',
+                                       '14fb3e68-4dca-46db-bf49-04b84e07e999')
             decoded_report = json.loads(report)
 
         self.assertEqual(decoded_report, self.reporting_response)
 
     @responses.activate
-    def test_reporting_details_malformed_collex(self):
+    def test_reporting_details_seft_success(self):
+        with self.app.app_context():
+            seft_reporting_response = {'metadata': {'collectionExerciseId': '14fb3e68-4dca-46db-bf49-04b84e07e999',
+                                                    'timeUpdated': 1533895381.534031},
+                                       'report': {'downloads': 259, 'accountsPending': 402, 'accountsEnrolled': 259,
+                                                  'notStarted': 457, 'uploads': 160, 'sampleSize': 716}}
+            responses.add(responses.GET, self.app.config['REPORTING_URL'] + '/reporting-api/v1/response-dashboard'
+                                                                            '/survey'
+                                                                            '/57586798-74e3-49fd-93da-a782ec5f5129'
+                                                                            '/collection-exercise'
+                                                                            '/14fb3e68-4dca-46db-bf49-04b84e07e999',
+                          json=self.reporting_response, status=200)
 
-        response = self.test_client.get('/dashboard/reporting/eq/collection-exercise/0002133304032532504')
+            report = reporting_details('seft',
+                                       '57586798-74e3-49fd-93da-a782ec5f5129',
+                                       '14fb3e68-4dca-46db-bf49-04b84e07e999')
+            decoded_report = json.loads(report)
+
+        self.assertEqual(decoded_report, seft_reporting_response)
+
+    @responses.activate
+    def test_reporting_details_malformed_collex(self):
+        response = self.test_client.get('/dashboard/reporting/eq'
+                                        '/survey/57586798-74e3-49fd-93da-a782ec5f5129'
+                                        '/collection-exercise/0002133304032532504')
         self.assertEqual(response.status_code, 404)
         self.assertIn(b'Sorry, we could not find the page you were looking for.', response.data)
 
     @responses.activate
     def test_reporting_details_invalid_CI_type(self):
-
-        response = self.test_client.get('/dashboard/reporting/SAFT/collection-exercise/14fb3e68-4dca-46db-bf49-04b84e07e999')
+        response = self.test_client.get('/dashboard/reporting/SAFT'
+                                        '/survey/57586798-74e3-49fd-93da-a782ec5f5129'
+                                        '/collection-exercise/14fb3e68-4dca-46db-bf49-04b84e07e999')
         self.assertEqual(response.status_code, 404)
         self.assertIn(b'Sorry, we could not find the page you were looking for.', response.data)
 
@@ -47,10 +70,13 @@ class TestReporting(AppContextTestCase):
     def test_reporting_details_invalid_collex(self):
         with self.app.app_context():
             responses.add(responses.GET, self.app.config['REPORTING_URL'] + '/reporting-api/v1/response-dashboard'
-                                                                            '/seft/'
-                                                                            'collection-exercise'
-                                                                            '/14fb3e68-4dca-46db-bf49'
-                                                                            '-04b84e07e997',
-                                                                            status=404)
-        response = self.test_client.get('/dashboard/reporting/seft/collection-exercise/14fb3e68-4dca-46db-bf49-04b84e07e997')
+                                                                            '/survey'
+                                                                            '/57586798-74e3-49fd-93da-a782ec5f5129'
+                                                                            '/collection-exercise'
+                                                                            '/00000000-0000-0000-0000'
+                                                                            '-0000000000000',
+                          status=404)
+        response = self.test_client.get('/dashboard/reporting/seft'
+                                        '/survey/57586798-74e3-49fd-93da-a782ec5f5129'
+                                        '/collection-exercise/00000000-0000-0000-0000-0000000000000')
         self.assertEqual(response.status_code, 404)

--- a/tests/app/controllers/test_reporting_controller.py
+++ b/tests/app/controllers/test_reporting_controller.py
@@ -1,5 +1,3 @@
-import json
-
 import responses
 
 from app.controllers.reporting_controller import get_reporting_details
@@ -7,7 +5,6 @@ from tests.app import AppContextTestCase
 
 
 class TestReportingController(AppContextTestCase):
-
     reporting_response = {'metadata': {'collectionExerciseId': '14fb3e68-4dca-46db-bf49-04b84e07e999',
                                        'timeUpdated': 1533895381.534031},
                           'report': {'inProgress': 99, 'accountsPending': 402, 'accountsEnrolled': 259,
@@ -17,14 +14,14 @@ class TestReportingController(AppContextTestCase):
     def test_get_reporting_details_success(self):
         with self.app.app_context():
             responses.add(responses.GET, self.app.config['REPORTING_URL'] + '/reporting-api/v1/response-dashboard'
-                                                                            '/seft/'
-                                                                            'collection-exercise'
+                                                                            '/survey'
+                                                                            '/57586798-74e3-49fd-93da-a782ec5f5129'
+                                                                            '/collection-exercise'
                                                                             '/14fb3e68-4dca-46db-bf49'
                                                                             '-04b84e07e999',
-                                                                            json=self.reporting_response, status=200)
+                          json=self.reporting_response, status=200)
 
-            report = get_reporting_details('seft', '14fb3e68-4dca-46db-bf49-04b84e07e999')
-            decoded_report = json.loads(report)
+            report = get_reporting_details('57586798-74e3-49fd-93da-a782ec5f5129',
+                                           '14fb3e68-4dca-46db-bf49-04b84e07e999')
 
-        self.assertEqual(decoded_report, self.reporting_response)
-
+        self.assertEqual(report, self.reporting_response)


### PR DESCRIPTION
# Motivation and Context
The reporting endpoint is changing to require a survey ID, and the reporting service no longer distinguishes between EQ and SEFT reports.

# What has changed
- Updated reporting API endpoint to pass survey ID but not collection instrument type
- Updated HTML with survey ID 
- Update JS to pass survey ID from HTML to reporting API gateway endpoint
- Updated tests
- Updated mock endpoints
- Fixed travis build

# How to test?
Run the service against this branch of rm-reporting: https://github.com/ONSdigital/rm-reporting/pull/15
It should still load the dashboard and show correct figures.

# Links
https://github.com/ONSdigital/rm-reporting/tree/88-dont-count-dummy-sample-units
https://trello.com/c/kp7foNVs/87-bug-accounts-enrolled-and-pending-counts-dont-filter-by-survey-id
https://trello.com/c/Kl95brGU/88-dont-count-dummy-sample-units
https://github.com/ONSdigital/rm-reporting/pull/15