### PR TITLE
Reorder SEFT figures, update mocks script for better figures

### DIFF
--- a/app/static/assets/js/reporting.js
+++ b/app/static/assets/js/reporting.js
@@ -1,18 +1,6 @@
 /*jshint esversion: 6 */
 function getReportSEFT(response) {
     const report = {
-        "downloads": {
-            "id": "downloads",
-            "title": "Downloads",
-            "value": response.report.downloads,
-            "class": "fa fa-download"
-        },
-        "uploads": {
-            "id": "uploads",
-            "title": "Uploads",
-            "value": response.report.uploads,
-            "class": "fa fa-upload"
-        },
         "accountsPending": {
             "id": "accounts-pending",
             "title": "Accounts Pending",
@@ -24,6 +12,18 @@ function getReportSEFT(response) {
             "title": "Accounts Enrolled",
             "value": response.report.accountsEnrolled,
             "class": "fa fa-users"
+        },
+        "downloads": {
+            "id": "downloads",
+            "title": "Downloads",
+            "value": response.report.downloads,
+            "class": "fa fa-download"
+        },
+        "uploads": {
+            "id": "uploads",
+            "title": "Uploads",
+            "value": response.report.uploads,
+            "class": "fa fa-upload"
         },
         "sampleSize": {
             "id": "sample-size",

--- a/scripts/mock_services.py
+++ b/scripts/mock_services.py
@@ -17,10 +17,10 @@ def get_report(survey_id, collection_exercise_id):
     rand_gen = SystemRandom()
 
     sample_size = rand_gen.randint(100, 1000)
-    accounts_pending = rand_gen.randint(0, sample_size)
-    downloads = rand_gen.randint(0, accounts_pending)
+    accounts_enrolled = rand_gen.randint(0, sample_size)
+    accounts_pending = rand_gen.randint(0, sample_size - accounts_enrolled)
+    downloads = rand_gen.randint(0, accounts_enrolled)
     uploads = rand_gen.randint(0, downloads)
-    accounts_enrolled = rand_gen.randint(uploads, accounts_pending)
 
     response = {
         'metadata': {


### PR DESCRIPTION
# Motivation and Context
SEFT collection exercises now show accounts pending and enrolled like EQ, so it should show those figures in the same arrangement for consistency

# What has changed
- Reordered SEFT report figures in dashboard
- Updated mock numbers to be more realistic

# How to test?
Run the dashboard, the SEFT figures should now be arranged more consistently with the EQ layout.

# Links
https://trello.com/c/y8z9IEj7/90-re-order-seft-figures-on-dashboard
