### PR TITLE
Replace 'End Date' With 'Return By Date' in Collection Exercise Menu

### DIFF
--- a/app/static/assets/js/datatables.js
+++ b/app/static/assets/js/datatables.js
@@ -91,9 +91,9 @@ function initialiseDataTables() {
 				"render": dateRender
 			},
 			{
-				"data": "periodEndDateTime",
-				"defaultContent": "No end date provided",
-				"title": "End Date",
+				"data": "scheduledReturnDateTime",
+				"defaultContent": "No return by date provided",
+				"title": "Return By Date",
 				"width": "25%",
 				"render": dateRender
 			}

--- a/app/survey_metadata.py
+++ b/app/survey_metadata.py
@@ -44,7 +44,7 @@ def map_surveys_to_collection_exercises(surveys, collection_exercises) -> list:
                     'userDescription': collection_exercise['userDescription'],
                     'exerciseRef': collection_exercise['exerciseRef'],
                     'periodStartDateTime': collection_exercise['periodStartDateTime'],
-                    'periodEndDateTime': collection_exercise['periodEndDateTime']
+                    'scheduledReturnDateTime': collection_exercise['scheduledReturnDateTime']
                 }
             )
         except KeyError as e:
@@ -71,7 +71,7 @@ def map_collection_exercise_id_to_survey_id(surveys_to_collection_exercises) -> 
                 'surveyType': survey['surveyType'],
                 'userDescription': collection_exercise['userDescription'],
                 'periodStartDateTime': collection_exercise['periodStartDateTime'],
-                'periodEndDateTime': collection_exercise['periodEndDateTime'],
+                'scheduledReturnDateTime': collection_exercise['scheduledReturnDateTime'],
                 'exerciseRef': collection_exercise['exerciseRef']
             }
 

--- a/tests/app/test_survey_metadata.py
+++ b/tests/app/test_survey_metadata.py
@@ -33,14 +33,14 @@ class TestSurveyMetadata(AppContextTestCase):
                         'userDescription': 'December 2017',
                         'exerciseRef': '201712',
                         'periodStartDateTime': '2017-09-14T23:00:00.000Z',
-                        'periodEndDateTime': '2017-09-15T22:59:59.000Z',
+                        'scheduledReturnDateTime': '2017-10-06T00:00:00.000Z',
                     },
                     {
                         'collectionExerciseId': '24fb3e68-4dca-46db-bf49-04b84e07e77c',
                         'userDescription': 'January 2018',
                         'exerciseRef': '201801',
                         'periodStartDateTime': '2017-09-14T23:00:00.000Z',
-                        'periodEndDateTime': '2017-09-15T22:59:59.000Z',
+                        'scheduledReturnDateTime': '2017-10-06T00:00:00.000Z',
                     }
                 ]
             },
@@ -66,7 +66,7 @@ class TestSurveyMetadata(AppContextTestCase):
                         'userDescription': 'Quarterly Business Survey',
                         'exerciseRef': '201812',
                         'periodStartDateTime': '2017-09-14T23:00:00.000Z',
-                        'periodEndDateTime': '2017-09-15T22:59:59.000Z',
+                        'scheduledReturnDateTime': '2017-10-06T00:00:00.000Z',
                     }
                 ]
             },
@@ -98,7 +98,7 @@ class TestSurveyMetadata(AppContextTestCase):
                  'surveyType': 'Business',
                  'surveyId': '04dbb407-4438-4f89-acc4-53445d753111',
                  'periodStartDateTime': '2017-09-14T23:00:00.000Z',
-                 'periodEndDateTime': '2017-09-15T22:59:59.000Z',
+                 'scheduledReturnDateTime': '2017-10-06T00:00:00.000Z',
                  'userDescription': 'Quarterly '
                                     'Business Survey'},
             '14fb3e68-4dca-46db-bf49-04b84e07e77c':
@@ -111,7 +111,7 @@ class TestSurveyMetadata(AppContextTestCase):
                  'surveyType': 'Business',
                  'surveyId': 'cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87',
                  'periodStartDateTime': '2017-09-14T23:00:00.000Z',
-                 'periodEndDateTime': '2017-09-15T22:59:59.000Z',
+                 'scheduledReturnDateTime': '2017-10-06T00:00:00.000Z',
                  'userDescription': 'December 2017'},
             '24fb3e68-4dca-46db-bf49-04b84e07e77c':
                 {'collectionInstrumentType': 'seft',
@@ -122,7 +122,7 @@ class TestSurveyMetadata(AppContextTestCase):
                  'surveyType': 'Business',
                  'surveyId': 'cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87',
                  'periodStartDateTime': '2017-09-14T23:00:00.000Z',
-                 'periodEndDateTime': '2017-09-15T22:59:59.000Z',
+                 'scheduledReturnDateTime': '2017-10-06T00:00:00.000Z',
                  'userDescription': 'January 2018'}
         }
 
@@ -154,7 +154,7 @@ class TestSurveyMetadata(AppContextTestCase):
                         'userDescription': 'January 2018',
                         'exerciseRef': '201801',
                             'periodStartDateTime': '2017-09-14T23:00:00.000Z',
-                        'periodEndDateTime': '2017-09-15T22:59:59.000Z'
+                        'scheduledReturnDateTime': '2017-10-06T00:00:00.000Z'
                     }
                 ]
             },
@@ -180,7 +180,7 @@ class TestSurveyMetadata(AppContextTestCase):
                         'userDescription': 'Quarterly Business Survey',
                         'exerciseRef': '201812',
                         'periodStartDateTime': '2017-09-14T23:00:00.000Z',
-                        'periodEndDateTime': '2017-09-15T22:59:59.000Z'
+                        'scheduledReturnDateTime': '2017-10-06T00:00:00.000Z'
                     }
                 ]
             }
@@ -196,7 +196,7 @@ class TestSurveyMetadata(AppContextTestCase):
                  'surveyType': 'Business',
                  'surveyId': '04dbb407-4438-4f89-acc4-53445d753111',
                  'periodStartDateTime': '2017-09-14T23:00:00.000Z',
-                 'periodEndDateTime': '2017-09-15T22:59:59.000Z',
+                 'scheduledReturnDateTime': '2017-10-06T00:00:00.000Z',
                  'userDescription': 'Quarterly Business Survey'},
             '24fb3e68-4dca-46db-bf49-04b84e07e77c':
                 {'collectionInstrumentType': 'seft',
@@ -207,7 +207,7 @@ class TestSurveyMetadata(AppContextTestCase):
                  'surveyType': 'Business',
                  'surveyId': 'cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87',
                  'periodStartDateTime': '2017-09-14T23:00:00.000Z',
-                 'periodEndDateTime': '2017-09-15T22:59:59.000Z',
+                 'scheduledReturnDateTime': '2017-10-06T00:00:00.000Z',
                  'userDescription': 'January 2018'}}
 
         self.assertEqual(expected_surveys,


### PR DESCRIPTION
# Motivation and Context
The 'End Date' does not really get used for business surveys, 'Return By Date' makes more sense to display in the menu as this is the date respondents are asked to submit by.

# What has changed
- Replace end date with return by date in collection exercise menu

# How to test?
Run the dashboard locally and check the end date is replaced with return by date in the collection exercise modal and that all other features still work the same.

# Links
https://trello.com/c/6MSuOixo/93-use-return-by-date-instead-of-end-date-in-collection-exercise-menu