### PR TITLE
Remove different behaviour for listed SEFT surveys

### DIFF
--- a/app/api/reporting.py
+++ b/app/api/reporting.py
@@ -12,12 +12,8 @@ reporting_blueprint = Blueprint(name='reporting', import_name=__name__, url_pref
 logger = get_logger()
 
 
-@reporting_blueprint.route('/reporting/<collection_instrument_type>'
-                           '/survey/<survey_id>'
-                           '/collection-exercise/<collex_id>', methods=['GET'])
-def reporting_details(collection_instrument_type, survey_id, collex_id):
-    ci_types = {'eq', 'seft'}
-
+@reporting_blueprint.route('/reporting/survey/<survey_id>/collection-exercise/<collex_id>', methods=['GET'])
+def reporting_details(survey_id, collex_id):
     parsed_survey_id = parse_uuid(survey_id)
     if not parsed_survey_id:
         logger.debug('Malformed collection exercise ID', invalid_survey_id=survey_id)
@@ -28,18 +24,10 @@ def reporting_details(collection_instrument_type, survey_id, collex_id):
         logger.debug('Malformed collection exercise ID', invalid_collex_id=collex_id)
         abort(404, 'Malformed collection exercise ID')
 
-    if not collection_instrument_type.lower() in ci_types:
-        logger.debug('Invalid CI type', ci_type=collection_instrument_type)
-        abort(404, 'Invalid CI type')
-
     try:
         report = get_reporting_details(parsed_survey_id, parsed_collex_id)
     except HTTPError:
         logger.debug('Invalid collection exercise or survey id')
         abort(404)
-
-    if collection_instrument_type == 'seft':
-        report['report']['uploads'] = report['report'].pop('completed')
-        report['report']['downloads'] = report['report'].pop('inProgress') + report['report']['uploads']
 
     return json.dumps(report)

--- a/app/static/assets/js/reporting.js
+++ b/app/static/assets/js/reporting.js
@@ -1,42 +1,5 @@
 /*jshint esversion: 6 */
-function getReportSEFT(response) {
-    const report = {
-        "accountsPending": {
-            "id": "accounts-pending",
-            "title": "Accounts Pending",
-            "value": response.report.accountsPending,
-            "class": "fa fa-user-plus"
-        },
-        "accountsEnrolled": {
-            "id": "accounts-enrolled",
-            "title": "Accounts Enrolled",
-            "value": response.report.accountsEnrolled,
-            "class": "fa fa-users"
-        },
-        "downloads": {
-            "id": "downloads",
-            "title": "Downloads",
-            "value": response.report.downloads,
-            "class": "fa fa-download"
-        },
-        "uploads": {
-            "id": "uploads",
-            "title": "Uploads",
-            "value": response.report.uploads,
-            "class": "fa fa-upload"
-        },
-        "sampleSize": {
-            "id": "sample-size",
-            "title": "Sample Size",
-            "value": response.report.sampleSize,
-            "class": "fa fa-sitemap fa-color-white"
-        }
-    };
-
-    return report;
-}
-
-function getReportEQ(response) {
+function getReport(response) {
     const report = {
         "accountsPending": {
             "id": "accounts-pending",
@@ -79,16 +42,13 @@ function getReportEQ(response) {
     return report;
 }
 
-function displayCollectionInstrumentData(collectionInstrumentType, response) {
+function displayCollectionExerciseData(response) {
 
     const timeUpdated = moment.unix(response.metadata.timeUpdated).calendar(); // eslint-disable-line
     let report = {};
 
-    if (collectionInstrumentType.toLowerCase() === "eq") {
-        report = getReportEQ(response);
-    } else {
-        report = getReportSEFT(response);
-    }
+    report = getReport(response);
+
     $("#counters").empty();
     /* eslint-disable */
     for (const figure in report) {
@@ -128,11 +88,10 @@ function callAPI() {
     const collexID = $("#collex-id").data("collex");
     const surveyID = $("#collex-id").data("survey");
     const reportingRefreshCycleInSeconds = $("#collex-id").data("reporting-refresh-cycle");
-    const collectionInstrumentType = $("#collex-id").data("collection-instrument-type");
 
     $.ajax({
         dataType: "json",
-        url: `/dashboard/reporting/${collectionInstrumentType}/survey/${surveyID}/collection-exercise/${collexID}`
+        url: `/dashboard/reporting/survey/${surveyID}/collection-exercise/${collexID}`
     }).done((result) => {
 
         $(".content-header").show();
@@ -141,7 +100,7 @@ function callAPI() {
         $("#loading").hide();
         $("#time-updated-label").show();
 
-        displayCollectionInstrumentData(collectionInstrumentType, result);
+        displayCollectionExerciseData(result);
     }).fail((result) => {
         $("#loading").hide();
         $(".content-header").hide();

--- a/app/static/assets/js/reporting.js
+++ b/app/static/assets/js/reporting.js
@@ -45,9 +45,7 @@ function getReport(response) {
 function displayCollectionExerciseData(response) {
 
     const timeUpdated = moment.unix(response.metadata.timeUpdated).calendar(); // eslint-disable-line
-    let report = {};
-
-    report = getReport(response);
+    let report = getReport(response);
 
     $("#counters").empty();
     /* eslint-disable */

--- a/app/survey_metadata.py
+++ b/app/survey_metadata.py
@@ -6,28 +6,11 @@ from app.exceptions import UnknownSurveyError
 
 logger = get_logger()
 
-SEFT_SURVEYS = {
-    'cb8accda-6118-4d3b-85a3-149e28960c54',  # Bricks
-    '9b6872eb-28ee-4c09-b705-c3ab1bb0f9ec',  # Blocks
-    'c48d6646-eb6f-4c7c-9f37-f7b41c8d2bc6',  # Sand & Gravel
-    '57a43c94-9f81-4f33-bad8-f94800a66503',  # QOFDI
-    'c3eaeff3-d570-475d-9859-32c3bf87800d',  # QIFDI
-    '04dbb407-4438-4f89-acc4-53445d75330c',  # AOFDI
-    '41320b22-b425-4fba-a90e-718898f718ce',  # AIFDI
-    '6aa8896f-ced5-4694-800c-6cd661b0c8b2',  # ASHE
-    'cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87',  # BRES
-    '0fc6fa22-8938-43b6-81c5-f1ccca5a5494',  # OFATS
-    '7a2c9d6c-9aaf-4cf0-a68c-1d50b3f1b296',  # NBS
-    '416b8a82-2031-4f41-b59b-95482d916ca3',  # PCS
-    'a81f8a72-47e1-4fcf-a88b-0c175829e02b'   # GoVERD
-}
-
 
 def map_surveys_to_collection_exercises(surveys, collection_exercises) -> list:
     survey_data = {
         survey['id']: {
             'surveyId': survey['id'],
-            'collectionInstrumentType': 'seft' if survey['id'] in SEFT_SURVEYS else 'eq',
             'shortName': survey['shortName'],
             'longName': survey['longName'],
             'surveyRef': survey['surveyRef'],
@@ -65,7 +48,6 @@ def map_collection_exercise_id_to_survey_id(surveys_to_collection_exercises) -> 
         for collection_exercise in survey['collectionExercises']:
             collection_exercises_to_survey_ids[collection_exercise['collectionExerciseId']] = {
                 'surveyId': survey['surveyId'],
-                'collectionInstrumentType': survey['collectionInstrumentType'],
                 'shortName': survey['shortName'],
                 'longName': survey['longName'],
                 'surveyType': survey['surveyType'],

--- a/app/templates/reporting.html
+++ b/app/templates/reporting.html
@@ -14,7 +14,7 @@
         <script src="https://cdnjs.cloudflare.com/ajax/libs/pace/1.0.2/pace.min.js"></script>
         <link href="https://cdnjs.cloudflare.com/ajax/libs/pace/1.0.2/themes/blue/pace-theme-flash.min.css" rel="stylesheet" />
 	</head>
-	<body id="collex-id" data-survey="{{ survey_id }}" data-collex="{{ collex_id }}" data-collection-instrument-type="{{ collection_instrument_type }}" data-reporting-refresh-cycle="{{ reporting_refresh_cycle }}" class="no-sidebar skin-black">
+	<body id="collex-id" data-survey="{{ survey_id }}" data-collex="{{ collex_id }}" data-reporting-refresh-cycle="{{ reporting_refresh_cycle }}" class="no-sidebar skin-black">
 		<div class="wrapper">
 			{% include 'partials/_header.html' %}
 			<!-- Content Wrapper. Contains page content -->

--- a/app/views/dashboard.py
+++ b/app/views/dashboard.py
@@ -36,7 +36,6 @@ def get_dashboard_for_collection_exercise(collection_exercise_id):
         'reporting.html',
         collex_id=collection_exercise_id,
         all_surveys=surveys_metadata,
-        collection_instrument_type=collection_exercise['collectionInstrumentType'],
         survey_short_name=collection_exercise['shortName'],
         survey_long_name=collection_exercise['longName'],
         survey_id=collection_exercise['surveyId'],

--- a/scripts/mock_services.py
+++ b/scripts/mock_services.py
@@ -18,7 +18,7 @@ def get_report(survey_id, collection_exercise_id):
 
     sample_size = rand_gen.randint(100, 1000)
     accounts_enrolled = rand_gen.randint(0, sample_size)
-    accounts_pending = rand_gen.randint(0, (sample_size - accounts_enrolled)//10)
+    accounts_pending = rand_gen.randint(0, (sample_size - accounts_enrolled) // 10)
     downloads = rand_gen.randint(0, accounts_enrolled)
     uploads = rand_gen.randint(0, downloads)
 

--- a/scripts/mock_services.py
+++ b/scripts/mock_services.py
@@ -18,7 +18,7 @@ def get_report(survey_id, collection_exercise_id):
 
     sample_size = rand_gen.randint(100, 1000)
     accounts_enrolled = rand_gen.randint(0, sample_size)
-    accounts_pending = rand_gen.randint(0, sample_size - accounts_enrolled)
+    accounts_pending = rand_gen.randint(0, (sample_size - accounts_enrolled)//10)
     downloads = rand_gen.randint(0, accounts_enrolled)
     uploads = rand_gen.randint(0, downloads)
 
@@ -283,4 +283,4 @@ def get_collection_exercises():
 
 
 if __name__ == "__main__":
-    app.run(host="localhost", port=5001)
+    app.run(host="localhost", port=5001, debug=True)

--- a/tests/app/api/test_reporting.py
+++ b/tests/app/api/test_reporting.py
@@ -13,7 +13,7 @@ class TestReporting(AppContextTestCase):
                                      'notStarted': 457, 'completed': 160, 'sampleSize': 716}}
 
     @responses.activate
-    def test_reporting_details_eq_success(self):
+    def test_reporting_details_success(self):
         with self.app.app_context():
             responses.add(responses.GET, self.app.config['REPORTING_URL'] + '/reporting-api/v1/response-dashboard'
                                                                             '/survey'
@@ -22,33 +22,11 @@ class TestReporting(AppContextTestCase):
                                                                             '/14fb3e68-4dca-46db-bf49-04b84e07e999',
                           json=self.reporting_response, status=200)
 
-            report = reporting_details('eq',
-                                       '57586798-74e3-49fd-93da-a782ec5f5129',
+            report = reporting_details('57586798-74e3-49fd-93da-a782ec5f5129',
                                        '14fb3e68-4dca-46db-bf49-04b84e07e999')
             decoded_report = json.loads(report)
 
         self.assertEqual(decoded_report, self.reporting_response)
-
-    @responses.activate
-    def test_reporting_details_seft_success(self):
-        with self.app.app_context():
-            seft_reporting_response = {'metadata': {'collectionExerciseId': '14fb3e68-4dca-46db-bf49-04b84e07e999',
-                                                    'timeUpdated': 1533895381.534031},
-                                       'report': {'downloads': 259, 'accountsPending': 402, 'accountsEnrolled': 259,
-                                                  'notStarted': 457, 'uploads': 160, 'sampleSize': 716}}
-            responses.add(responses.GET, self.app.config['REPORTING_URL'] + '/reporting-api/v1/response-dashboard'
-                                                                            '/survey'
-                                                                            '/57586798-74e3-49fd-93da-a782ec5f5129'
-                                                                            '/collection-exercise'
-                                                                            '/14fb3e68-4dca-46db-bf49-04b84e07e999',
-                          json=self.reporting_response, status=200)
-
-            report = reporting_details('seft',
-                                       '57586798-74e3-49fd-93da-a782ec5f5129',
-                                       '14fb3e68-4dca-46db-bf49-04b84e07e999')
-            decoded_report = json.loads(report)
-
-        self.assertEqual(decoded_report, seft_reporting_response)
 
     def test_reporting_details_malformed_collex_id(self):
         response = self.test_client.get('/dashboard/reporting/eq'
@@ -60,13 +38,6 @@ class TestReporting(AppContextTestCase):
     def test_reporting_details_malformed_survey_id(self):
         response = self.test_client.get('/dashboard/reporting/eq'
                                         '/survey/not-a-valid-uuid-format'
-                                        '/collection-exercise/14fb3e68-4dca-46db-bf49-04b84e07e999')
-        self.assertEqual(response.status_code, 404)
-        self.assertIn(b'Sorry, we could not find the page you were looking for.', response.data)
-
-    def test_reporting_details_invalid_CI_type(self):
-        response = self.test_client.get('/dashboard/reporting/SAFT'
-                                        '/survey/57586798-74e3-49fd-93da-a782ec5f5129'
                                         '/collection-exercise/14fb3e68-4dca-46db-bf49-04b84e07e999')
         self.assertEqual(response.status_code, 404)
         self.assertIn(b'Sorry, we could not find the page you were looking for.', response.data)

--- a/tests/app/api/test_reporting.py
+++ b/tests/app/api/test_reporting.py
@@ -29,14 +29,14 @@ class TestReporting(AppContextTestCase):
         self.assertEqual(decoded_report, self.reporting_response)
 
     def test_reporting_details_malformed_collex_id(self):
-        response = self.test_client.get('/dashboard/reporting/eq'
+        response = self.test_client.get('/dashboard/reporting'
                                         '/survey/57586798-74e3-49fd-93da-a782ec5f5129'
                                         '/collection-exercise/not-a-valid-uuid-format')
         self.assertEqual(response.status_code, 404)
         self.assertIn(b'Sorry, we could not find the page you were looking for.', response.data)
 
     def test_reporting_details_malformed_survey_id(self):
-        response = self.test_client.get('/dashboard/reporting/eq'
+        response = self.test_client.get('/dashboard/reporting'
                                         '/survey/not-a-valid-uuid-format'
                                         '/collection-exercise/14fb3e68-4dca-46db-bf49-04b84e07e999')
         self.assertEqual(response.status_code, 404)
@@ -52,7 +52,7 @@ class TestReporting(AppContextTestCase):
                                                                             '/00000000-0000-0000-0000'
                                                                             '-0000000000000',
                           status=404)
-        response = self.test_client.get('/dashboard/reporting/seft'
+        response = self.test_client.get('/dashboard/reporting'
                                         '/survey/57586798-74e3-49fd-93da-a782ec5f5129'
                                         '/collection-exercise/00000000-0000-0000-0000-0000000000000')
         self.assertEqual(response.status_code, 404)

--- a/tests/app/test_survey_metadata.py
+++ b/tests/app/test_survey_metadata.py
@@ -25,7 +25,6 @@ class TestSurveyMetadata(AppContextTestCase):
                 'shortName': 'BRES',
                 'surveyType': 'Business',
                 'longName': 'Business Register and Employment Survey',
-                'collectionInstrumentType': 'seft',
                 'surveyRef': '221',
                 'collectionExercises': [
                     {
@@ -48,14 +47,12 @@ class TestSurveyMetadata(AppContextTestCase):
                 'surveyId': '04dbb407-4438-4f89-acc4-53445d75330c',
                 'shortName': 'AOFDI',
                 'surveyType': 'Business',
-                'collectionInstrumentType': 'seft',
                 'longName': 'Annual Outward Foreign Direct Investment Survey',
                 'surveyRef': '063',
                 'collectionExercises': []
             },
             {
                 'surveyId': '04dbb407-4438-4f89-acc4-53445d753111',
-                'collectionInstrumentType': 'eq',
                 'shortName': 'QBS',
                 'surveyType': 'Business',
                 'longName': 'Quarterly Business Survey',
@@ -72,7 +69,6 @@ class TestSurveyMetadata(AppContextTestCase):
             },
             {
                 'surveyId': '56dbb407-4438-4f89-acc4-53445d753111',
-                'collectionInstrumentType': 'eq',
                 'shortName': 'LMS',
                 'longName': 'Labour Market Survey',
                 'surveyRef': '999',
@@ -90,8 +86,7 @@ class TestSurveyMetadata(AppContextTestCase):
     def test_map_collection_exercise_id_to_survey_id(self):
         expected_result = {
             '14fb3e68-4dca-46db-bf49-04b84e07e777':
-                {'collectionInstrumentType': 'eq',
-                 'exerciseRef': '201812',
+                {'exerciseRef': '201812',
                  'longName': 'Quarterly Business '
                              'Survey',
                  'shortName': 'QBS',
@@ -102,9 +97,7 @@ class TestSurveyMetadata(AppContextTestCase):
                  'userDescription': 'Quarterly '
                                     'Business Survey'},
             '14fb3e68-4dca-46db-bf49-04b84e07e77c':
-                {'collectionInstrumentType': 'seft',
-
-                 'exerciseRef': '201712',
+                {'exerciseRef': '201712',
                  'longName': 'Business Register and '
                              'Employment Survey',
                  'shortName': 'BRES',
@@ -114,8 +107,7 @@ class TestSurveyMetadata(AppContextTestCase):
                  'scheduledReturnDateTime': '2017-10-06T00:00:00.000Z',
                  'userDescription': 'December 2017'},
             '24fb3e68-4dca-46db-bf49-04b84e07e77c':
-                {'collectionInstrumentType': 'seft',
-                 'exerciseRef': '201801',
+                {'exerciseRef': '201801',
                  'longName': 'Business Register and '
                              'Employment Survey',
                  'shortName': 'BRES',
@@ -144,7 +136,6 @@ class TestSurveyMetadata(AppContextTestCase):
             {
                 'surveyId': 'cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87',
                 'shortName': 'BRES',
-                'collectionInstrumentType': 'seft',
                 'longName': 'Business Register and Employment Survey',
                 'surveyRef': '221',
                 'surveyType': 'Business',
@@ -161,7 +152,6 @@ class TestSurveyMetadata(AppContextTestCase):
             {
                 'surveyId': '04dbb407-4438-4f89-acc4-53445d75330c',
                 'shortName': 'AOFDI',
-                'collectionInstrumentType': 'seft',
                 'longName': 'Annual Outward Foreign Direct Investment Survey',
                 'surveyRef': '063',
                 'surveyType': 'Business',
@@ -169,7 +159,6 @@ class TestSurveyMetadata(AppContextTestCase):
             },
             {
                 'surveyId': '04dbb407-4438-4f89-acc4-53445d753111',
-                'collectionInstrumentType': 'eq',
                 'shortName': 'QBS',
                 'longName': 'Quarterly Business Survey',
                 'surveyRef': '064',
@@ -188,8 +177,7 @@ class TestSurveyMetadata(AppContextTestCase):
 
         expected_collection_exercises = {
             '14fb3e68-4dca-46db-bf49-04b84e07e777':
-                {'collectionInstrumentType': 'eq',
-                 'exerciseRef': '201812',
+                {'exerciseRef': '201812',
                  'longName': 'Quarterly Business '
                              'Survey',
                  'shortName': 'QBS',
@@ -199,8 +187,7 @@ class TestSurveyMetadata(AppContextTestCase):
                  'scheduledReturnDateTime': '2017-10-06T00:00:00.000Z',
                  'userDescription': 'Quarterly Business Survey'},
             '24fb3e68-4dca-46db-bf49-04b84e07e77c':
-                {'collectionInstrumentType': 'seft',
-                 'exerciseRef': '201801',
+                {'exerciseRef': '201801',
                  'longName': 'Business Register and '
                              'Employment Survey',
                  'shortName': 'BRES',


### PR DESCRIPTION
# Motivation and Context
We cannot currently reliably tell which collection exercises are SEFT versus EQ, the solution we had with a hardcoded list is not sustainable and needs to be removed. This PR removes all different behaviours for SEFT and removes the hardcoded list of ID's. The dashboard now treats all collection exercises the same.

# What has changed
- Removed list of SEFT survey ID's
- Removed all different behaviour for SEFT collection exercises

# How to test?
Run the dashboard, open a SEFT collection exercise. It should now show the same figures as the EQ dashboards.