### PR TITLE
Prevent progress bar from displaying NaN if sample size is zero

### DIFF
--- a/app/static/assets/js/reporting.js
+++ b/app/static/assets/js/reporting.js
@@ -115,7 +115,7 @@ function displayCollectionInstrumentData(collectionInstrumentType, response) {
     }
     /* eslint-enable */
 
-    const progress = (report.uploads.value / report.sampleSize.value * 100).toFixed(2);
+    const progress = (report.uploads.value / report.sampleSize.value * 100) || 0
 
     $("#sample-size-box").removeClass("bg-ons-light-blue").addClass("bg-ons-blue");
     $("#progress-uploaded").text(report.uploads.value);

--- a/app/static/assets/js/reporting.js
+++ b/app/static/assets/js/reporting.js
@@ -121,7 +121,7 @@ function displayCollectionInstrumentData(collectionInstrumentType, response) {
     $("#progress-uploaded").text(report.uploads.value);
     $("#time-updated").text(timeUpdated);
     $("#progress-size").text(report.sampleSize.value);
-    $("#collex-progress").text(`${progress}%`).css("width", `${progress}%`);
+    $("#collex-progress").text(`${progress.toFixed()}%`).css("width", `${progress}%`);
 }
 
 function callAPI() {


### PR DESCRIPTION
### Motivation and Context
Handles NaN for progress bar value in the event that the number is not a number.

### What has changed
JS change to default to 0 if NaN

### How to test?
Test with a sample size of 0.