### PR TITLE
Use execution/go live date for start date in CE selection modal

### DIFF
--- a/app/static/assets/js/datatables.js
+++ b/app/static/assets/js/datatables.js
@@ -84,9 +84,9 @@ function initialiseDataTables() {
 				"width": "50%"
 			},
 			{
-				"data": "periodStartDateTime",
-				"defaultContent": "No start date provided",
-				"title": "Start Date",
+				"data": "scheduledExecutionDateTime",
+				"defaultContent": "No go live provided",
+				"title": "Go Live Date",
 				"width": "25%",
 				"render": dateRender
 			},

--- a/app/survey_metadata.py
+++ b/app/survey_metadata.py
@@ -26,7 +26,7 @@ def map_surveys_to_collection_exercises(surveys, collection_exercises) -> list:
                     'collectionExerciseId': collection_exercise['id'],
                     'userDescription': collection_exercise['userDescription'],
                     'exerciseRef': collection_exercise['exerciseRef'],
-                    'periodStartDateTime': collection_exercise['periodStartDateTime'],
+                    'scheduledExecutionDateTime': collection_exercise['scheduledExecutionDateTime'],
                     'scheduledReturnDateTime': collection_exercise['scheduledReturnDateTime']
                 }
             )
@@ -52,7 +52,7 @@ def map_collection_exercise_id_to_survey_id(surveys_to_collection_exercises) -> 
                 'longName': survey['longName'],
                 'surveyType': survey['surveyType'],
                 'userDescription': collection_exercise['userDescription'],
-                'periodStartDateTime': collection_exercise['periodStartDateTime'],
+                'scheduledExecutionDateTime': collection_exercise['scheduledExecutionDateTime'],
                 'scheduledReturnDateTime': collection_exercise['scheduledReturnDateTime'],
                 'exerciseRef': collection_exercise['exerciseRef']
             }

--- a/config.py
+++ b/config.py
@@ -26,7 +26,7 @@ class Config:
     AUTH_PASSWORD = os.getenv('AUTH_PASSWORD')
     LOGGING_LEVEL = os.getenv('LOGGING_LEVEL', 'INFO')
     LOGGING_JSON_INDENT = os.getenv('LOGGING_JSON_INDENT')
-    STATIC_ASSETS_VERSION = os.getenv('STATIC_ASSETS_VERSION', '1.1.1')  # Defaulted until releases
+    STATIC_ASSETS_VERSION = os.getenv('STATIC_ASSETS_VERSION', '1.1.2')  # Defaulted until releases
 
 
 class DevelopmentConfig(Config):

--- a/tests/app/test_survey_metadata.py
+++ b/tests/app/test_survey_metadata.py
@@ -88,8 +88,7 @@ class TestSurveyMetadata(AppContextTestCase):
             '14fb3e68-4dca-46db-bf49-04b84e07e777':
                 {
                     'exerciseRef': '201812',
-                    'longName': 'Quarterly Business '
-                                'Survey',
+                    'longName': 'Quarterly Business Survey',
                     'scheduledExecutionDateTime': '2017-09-10T23:00:00.000Z',
                     'scheduledReturnDateTime': '2017-10-06T00:00:00.000Z',
                     'shortName': 'QBS',
@@ -100,8 +99,7 @@ class TestSurveyMetadata(AppContextTestCase):
             '14fb3e68-4dca-46db-bf49-04b84e07e77c':
                 {
                     'exerciseRef': '201712',
-                    'longName': 'Business Register and '
-                                'Employment Survey',
+                    'longName': 'Business Register and Employment Survey',
                     'scheduledExecutionDateTime': '2017-09-10T23:00:00.000Z',
                     'scheduledReturnDateTime': '2017-10-06T00:00:00.000Z',
                     'shortName': 'BRES',
@@ -111,8 +109,7 @@ class TestSurveyMetadata(AppContextTestCase):
             '24fb3e68-4dca-46db-bf49-04b84e07e77c':
                 {
                     'exerciseRef': '201801',
-                    'longName': 'Business Register and '
-                                'Employment Survey',
+                    'longName': 'Business Register and Employment Survey',
                     'scheduledExecutionDateTime': '2017-09-10T23:00:00.000Z',
                     'scheduledReturnDateTime': '2017-10-06T00:00:00.000Z',
                     'shortName': 'BRES',

--- a/tests/app/test_survey_metadata.py
+++ b/tests/app/test_survey_metadata.py
@@ -4,8 +4,8 @@ import os
 import responses
 
 from app.exceptions import UnknownSurveyError
-from app.survey_metadata import map_surveys_to_collection_exercises, map_collection_exercise_id_to_survey_id, \
-    fetch_survey_and_collection_exercise_metadata
+from app.survey_metadata import fetch_survey_and_collection_exercise_metadata, map_collection_exercise_id_to_survey_id, \
+    map_surveys_to_collection_exercises
 from tests.app import AppContextTestCase
 
 
@@ -31,14 +31,14 @@ class TestSurveyMetadata(AppContextTestCase):
                         'collectionExerciseId': '14fb3e68-4dca-46db-bf49-04b84e07e77c',
                         'userDescription': 'December 2017',
                         'exerciseRef': '201712',
-                        'periodStartDateTime': '2017-09-14T23:00:00.000Z',
+                        'scheduledExecutionDateTime': '2017-09-10T23:00:00.000Z',
                         'scheduledReturnDateTime': '2017-10-06T00:00:00.000Z',
                     },
                     {
                         'collectionExerciseId': '24fb3e68-4dca-46db-bf49-04b84e07e77c',
                         'userDescription': 'January 2018',
                         'exerciseRef': '201801',
-                        'periodStartDateTime': '2017-09-14T23:00:00.000Z',
+                        'scheduledExecutionDateTime': '2017-09-10T23:00:00.000Z',
                         'scheduledReturnDateTime': '2017-10-06T00:00:00.000Z',
                     }
                 ]
@@ -62,7 +62,7 @@ class TestSurveyMetadata(AppContextTestCase):
                         'collectionExerciseId': '14fb3e68-4dca-46db-bf49-04b84e07e777',
                         'userDescription': 'Quarterly Business Survey',
                         'exerciseRef': '201812',
-                        'periodStartDateTime': '2017-09-14T23:00:00.000Z',
+                        'scheduledExecutionDateTime': '2017-09-10T23:00:00.000Z',
                         'scheduledReturnDateTime': '2017-10-06T00:00:00.000Z',
                     }
                 ]
@@ -85,38 +85,34 @@ class TestSurveyMetadata(AppContextTestCase):
 
     def test_map_collection_exercise_id_to_survey_id(self):
         expected_result = {
-            '14fb3e68-4dca-46db-bf49-04b84e07e777':
-                {'exerciseRef': '201812',
-                 'longName': 'Quarterly Business '
-                             'Survey',
-                 'shortName': 'QBS',
-                 'surveyType': 'Business',
-                 'surveyId': '04dbb407-4438-4f89-acc4-53445d753111',
-                 'periodStartDateTime': '2017-09-14T23:00:00.000Z',
-                 'scheduledReturnDateTime': '2017-10-06T00:00:00.000Z',
-                 'userDescription': 'Quarterly '
-                                    'Business Survey'},
-            '14fb3e68-4dca-46db-bf49-04b84e07e77c':
-                {'exerciseRef': '201712',
-                 'longName': 'Business Register and '
-                             'Employment Survey',
-                 'shortName': 'BRES',
-                 'surveyType': 'Business',
-                 'surveyId': 'cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87',
-                 'periodStartDateTime': '2017-09-14T23:00:00.000Z',
-                 'scheduledReturnDateTime': '2017-10-06T00:00:00.000Z',
-                 'userDescription': 'December 2017'},
-            '24fb3e68-4dca-46db-bf49-04b84e07e77c':
-                {'exerciseRef': '201801',
-                 'longName': 'Business Register and '
-                             'Employment Survey',
-                 'shortName': 'BRES',
-                 'surveyType': 'Business',
-                 'surveyId': 'cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87',
-                 'periodStartDateTime': '2017-09-14T23:00:00.000Z',
-                 'scheduledReturnDateTime': '2017-10-06T00:00:00.000Z',
-                 'userDescription': 'January 2018'}
-        }
+            '14fb3e68-4dca-46db-bf49-04b84e07e777': {'exerciseRef': '201812',
+                                                     'longName': 'Quarterly Business '
+                                                                 'Survey',
+                                                     'scheduledExecutionDateTime': '2017-09-10T23:00:00.000Z',
+                                                     'scheduledReturnDateTime': '2017-10-06T00:00:00.000Z',
+                                                     'shortName': 'QBS',
+                                                     'surveyId': '04dbb407-4438-4f89-acc4-53445d753111',
+                                                     'surveyType': 'Business',
+                                                     'userDescription': 'Quarterly '
+                                                                        'Business Survey'},
+            '14fb3e68-4dca-46db-bf49-04b84e07e77c': {'exerciseRef': '201712',
+                                                     'longName': 'Business Register and '
+                                                                 'Employment Survey',
+                                                     'scheduledExecutionDateTime': '2017-09-10T23:00:00.000Z',
+                                                     'scheduledReturnDateTime': '2017-10-06T00:00:00.000Z',
+                                                     'shortName': 'BRES',
+                                                     'surveyId': 'cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87',
+                                                     'surveyType': 'Business',
+                                                     'userDescription': 'December 2017'},
+            '24fb3e68-4dca-46db-bf49-04b84e07e77c': {'exerciseRef': '201801',
+                                                     'longName': 'Business Register and '
+                                                                 'Employment Survey',
+                                                     'scheduledExecutionDateTime': '2017-09-10T23:00:00.000Z',
+                                                     'scheduledReturnDateTime': '2017-10-06T00:00:00.000Z',
+                                                     'shortName': 'BRES',
+                                                     'surveyId': 'cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87',
+                                                     'surveyType': 'Business',
+                                                     'userDescription': 'January 2018'}}
 
         actual_result = map_collection_exercise_id_to_survey_id(
             map_surveys_to_collection_exercises(self.surveys_response, self.collection_exercises_response))
@@ -144,7 +140,7 @@ class TestSurveyMetadata(AppContextTestCase):
                         'collectionExerciseId': '24fb3e68-4dca-46db-bf49-04b84e07e77c',
                         'userDescription': 'January 2018',
                         'exerciseRef': '201801',
-                        'periodStartDateTime': '2017-09-14T23:00:00.000Z',
+                        'scheduledExecutionDateTime': '2017-09-10T23:00:00.000Z',
                         'scheduledReturnDateTime': '2017-10-06T00:00:00.000Z'
                     }
                 ]
@@ -168,7 +164,7 @@ class TestSurveyMetadata(AppContextTestCase):
                         'collectionExerciseId': '14fb3e68-4dca-46db-bf49-04b84e07e777',
                         'userDescription': 'Quarterly Business Survey',
                         'exerciseRef': '201812',
-                        'periodStartDateTime': '2017-09-14T23:00:00.000Z',
+                        'scheduledExecutionDateTime': '2017-09-10T23:00:00.000Z',
                         'scheduledReturnDateTime': '2017-10-06T00:00:00.000Z'
                     }
                 ]
@@ -183,7 +179,7 @@ class TestSurveyMetadata(AppContextTestCase):
                  'shortName': 'QBS',
                  'surveyType': 'Business',
                  'surveyId': '04dbb407-4438-4f89-acc4-53445d753111',
-                 'periodStartDateTime': '2017-09-14T23:00:00.000Z',
+                 'scheduledExecutionDateTime': '2017-09-10T23:00:00.000Z',
                  'scheduledReturnDateTime': '2017-10-06T00:00:00.000Z',
                  'userDescription': 'Quarterly Business Survey'},
             '24fb3e68-4dca-46db-bf49-04b84e07e77c':
@@ -193,7 +189,7 @@ class TestSurveyMetadata(AppContextTestCase):
                  'shortName': 'BRES',
                  'surveyType': 'Business',
                  'surveyId': 'cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87',
-                 'periodStartDateTime': '2017-09-14T23:00:00.000Z',
+                 'scheduledExecutionDateTime': '2017-09-10T23:00:00.000Z',
                  'scheduledReturnDateTime': '2017-10-06T00:00:00.000Z',
                  'userDescription': 'January 2018'}}
 

--- a/tests/app/test_survey_metadata.py
+++ b/tests/app/test_survey_metadata.py
@@ -85,34 +85,40 @@ class TestSurveyMetadata(AppContextTestCase):
 
     def test_map_collection_exercise_id_to_survey_id(self):
         expected_result = {
-            '14fb3e68-4dca-46db-bf49-04b84e07e777': {'exerciseRef': '201812',
-                                                     'longName': 'Quarterly Business '
-                                                                 'Survey',
-                                                     'scheduledExecutionDateTime': '2017-09-10T23:00:00.000Z',
-                                                     'scheduledReturnDateTime': '2017-10-06T00:00:00.000Z',
-                                                     'shortName': 'QBS',
-                                                     'surveyId': '04dbb407-4438-4f89-acc4-53445d753111',
-                                                     'surveyType': 'Business',
-                                                     'userDescription': 'Quarterly '
-                                                                        'Business Survey'},
-            '14fb3e68-4dca-46db-bf49-04b84e07e77c': {'exerciseRef': '201712',
-                                                     'longName': 'Business Register and '
-                                                                 'Employment Survey',
-                                                     'scheduledExecutionDateTime': '2017-09-10T23:00:00.000Z',
-                                                     'scheduledReturnDateTime': '2017-10-06T00:00:00.000Z',
-                                                     'shortName': 'BRES',
-                                                     'surveyId': 'cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87',
-                                                     'surveyType': 'Business',
-                                                     'userDescription': 'December 2017'},
-            '24fb3e68-4dca-46db-bf49-04b84e07e77c': {'exerciseRef': '201801',
-                                                     'longName': 'Business Register and '
-                                                                 'Employment Survey',
-                                                     'scheduledExecutionDateTime': '2017-09-10T23:00:00.000Z',
-                                                     'scheduledReturnDateTime': '2017-10-06T00:00:00.000Z',
-                                                     'shortName': 'BRES',
-                                                     'surveyId': 'cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87',
-                                                     'surveyType': 'Business',
-                                                     'userDescription': 'January 2018'}}
+            '14fb3e68-4dca-46db-bf49-04b84e07e777':
+                {
+                    'exerciseRef': '201812',
+                    'longName': 'Quarterly Business '
+                                'Survey',
+                    'scheduledExecutionDateTime': '2017-09-10T23:00:00.000Z',
+                    'scheduledReturnDateTime': '2017-10-06T00:00:00.000Z',
+                    'shortName': 'QBS',
+                    'surveyId': '04dbb407-4438-4f89-acc4-53445d753111',
+                    'surveyType': 'Business',
+                    'userDescription': 'Quarterly '
+                                       'Business Survey'},
+            '14fb3e68-4dca-46db-bf49-04b84e07e77c':
+                {
+                    'exerciseRef': '201712',
+                    'longName': 'Business Register and '
+                                'Employment Survey',
+                    'scheduledExecutionDateTime': '2017-09-10T23:00:00.000Z',
+                    'scheduledReturnDateTime': '2017-10-06T00:00:00.000Z',
+                    'shortName': 'BRES',
+                    'surveyId': 'cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87',
+                    'surveyType': 'Business',
+                    'userDescription': 'December 2017'},
+            '24fb3e68-4dca-46db-bf49-04b84e07e77c':
+                {
+                    'exerciseRef': '201801',
+                    'longName': 'Business Register and '
+                                'Employment Survey',
+                    'scheduledExecutionDateTime': '2017-09-10T23:00:00.000Z',
+                    'scheduledReturnDateTime': '2017-10-06T00:00:00.000Z',
+                    'shortName': 'BRES',
+                    'surveyId': 'cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87',
+                    'surveyType': 'Business',
+                    'userDescription': 'January 2018'}}
 
         actual_result = map_collection_exercise_id_to_survey_id(
             map_surveys_to_collection_exercises(self.surveys_response, self.collection_exercises_response))


### PR DESCRIPTION
### Motivation and Context
Changes the start date in the collection exercise selection modal to use the execution (go live) date as this is representative of the actual survey start date. Previously it was using the period start date which is a reference date for the questions, not the actual survey execution.

### What has changed
- Change the survey metadata helper functions to use execution date
- Change the modal javascript to use the execution date
- Update unit tests
- Update static assets version

### How to test?
Run the service locally, the collection exercise selection menu should now show the go live date not the period start date

### Links
https://trello.com/c/Zmpzyepx/102-use-go-live-date-for-start-date-on-the-collection-exercise-selection-modal

### Checklist

* [x] STATIC_ASSETS_VERSION updated.