### PR TITLE
Adding docker files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nikolaik/python-nodejs:latest
+FROM mhart/alpine-node
 
 WORKDIR /app
 COPY . /app
@@ -8,8 +8,11 @@ COPY package*.json ./
 COPY yarn.lock ./
 RUN yarn compile
 
+FROM python:alpine3.6
+
+WORKDIR /app
+COPY --from=0 /app /app
 RUN pip3 install -U pipenv && pipenv install --system --deploy
 
 ENTRYPOINT ["python3"]
 CMD ["run.py"]
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mhart/alpine-node
+FROM node:8.15.0-alpine
 
 WORKDIR /app
 COPY . /app
@@ -8,11 +8,11 @@ COPY package*.json ./
 COPY yarn.lock ./
 RUN yarn compile
 
-FROM python:alpine3.6
+FROM python:3.6.8-alpine
 
 WORKDIR /app
 COPY --from=0 /app /app
-RUN pip3 install -U pipenv && pipenv install --system --deploy
+RUN pip3 install -U pipenv==2018.11.26 && pipenv install --system --deploy
 
 ENTRYPOINT ["python3"]
 CMD ["run.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM nikolaik/python-nodejs:latest
+
+WORKDIR /app
+COPY . /app
+EXPOSE 8078
+
+COPY package*.json ./
+COPY yarn.lock ./
+RUN yarn compile
+
+RUN pip3 install -U pipenv && pipenv install --system --deploy
+
+ENTRYPOINT ["python3"]
+CMD ["run.py"]
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,14 @@
-FROM node:8.15.0-alpine
-
+FROM node:11.7-alpine AS yarn-compile
 WORKDIR /app
 COPY . /app
 EXPOSE 8078
-
 COPY package*.json ./
 COPY yarn.lock ./
 RUN yarn compile
 
-FROM python:3.6.8-alpine
-
+FROM python:3.6.8-alpine AS python-app
 WORKDIR /app
-COPY --from=0 /app /app
+COPY --from=yarn-compile /app /app
 RUN pip3 install -U pipenv==2018.11.26 && pipenv install --system --deploy
-
 ENTRYPOINT ["python3"]
 CMD ["run.py"]

--- a/README.md
+++ b/README.md
@@ -67,7 +67,20 @@ Run the server inside the virtual env created by Pipenv with
 ```bash
 pipenv run python run.py
 ```
+## Docker
 
+To run with ras-rm docker-dev:
+```
+docker build -t sdcplatform/sdc-responses-dashboard .
+docker-compose up -d
+```
+If you want to run with mock services, change urls to:
+```
+REPORTING_URL=http://localhost:5001
+COLLECTION_EXERCISE_URL=http://localhost:5001
+SURVEY_URL=http://localhost:5001
+```
+and run `mock_services.py`
 ## Running in Isolation
 To run the dashboard without any of the external services it calls, this repo includes a basic flask app which mocks
 the external services.

--- a/README.md
+++ b/README.md
@@ -74,11 +74,12 @@ To run with ras-rm docker-dev:
 docker build -t sdcplatform/sdc-responses-dashboard .
 docker-compose up -d
 ```
-If you want to run with mock services, change urls to:
+If you want to run with mock services, you need to change the host to `host.docker.internal` to allow it to connect to
+localhost connection.
 ```
-REPORTING_URL=http://localhost:5001
-COLLECTION_EXERCISE_URL=http://localhost:5001
-SURVEY_URL=http://localhost:5001
+REPORTING_URL=http://host.docker.internal:5001
+COLLECTION_EXERCISE_URL=http://host.docker.internal:5001
+SURVEY_URL=http://host.docker.internal:5001
 ```
 and run `mock_services.py`
 ## Running in Isolation

--- a/config.py
+++ b/config.py
@@ -31,7 +31,7 @@ class Config:
 
 class DevelopmentConfig(Config):
     DEBUG = os.getenv('DEBUG', True)
-    PORT = os.getenv('PORT', '5000')
+    PORT = os.getenv('PORT', '8078')
     HOST = os.getenv('HOST', 'localhost')
     ENV = os.getenv('FLASK_ENV', 'development')
     COLLECTION_EXERCISE_URL = os.getenv('COLLECTION_EXERCISE_URL', 'http://localhost:8145')
@@ -50,7 +50,7 @@ class TestingConfig(Config):
     COLLECTION_EXERCISE_URL = testing_url
     SURVEY_URL = testing_url
     REPORTING_URL = testing_url
-    PORT = '5000'
+    PORT = '8078'
     HOST = 'localhost'
     TESTING = True
     ENV = 'testing'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+version: '3'
+services:
+    sdc-responses-dashboard:
+        ports:
+            - '8078:8078'
+        container_name: sdc-responses-dashboard
+        environment:
+            - APP_SETTINGS=DevelopmentConfig
+            - AUTH_PASSWORD=secret
+            - AUTH_USERNAME=admin
+            - PORT=8078
+            - HOST=0.0.0.0
+            - COLLECTION_EXERCISE_URL=http://collex:8145
+            - SURVEY_URL=http://survey:8080
+            - REPORTING_URL=http://host.docker.internal:8084
+            - REPORTING_REFRESH_CYCLE_IN_SECONDS=10
+        image: 'sdc-responses-dashboard:latest'
+        networks:
+            - rasrmdockerdev_default
+networks:
+   rasrmdockerdev_default:
+     external: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
             - SURVEY_URL=http://survey:8080
             - REPORTING_URL=http://host.docker.internal:8084
             - REPORTING_REFRESH_CYCLE_IN_SECONDS=10
-        image: 'sdc-responses-dashboard:latest'
+        image: 'sdcplatform/sdc-responses-dashboard:latest'
         networks:
             - rasrmdockerdev_default
 networks:

--- a/tests/functional/test_config.py
+++ b/tests/functional/test_config.py
@@ -2,6 +2,6 @@ import os
 
 
 class TestConfig:
-    DASHBOARD_URL = os.getenv('DASHBOARD_URL', 'http://localhost:5000')
+    DASHBOARD_URL = os.getenv('DASHBOARD_URL', 'http://localhost:8078')
     AUTH_USERNAME = os.getenv('AUTH_USERNAME', 'admin')
     AUTH_PASSWORD = os.getenv('AUTH_PASSWORD', 'secret')


### PR DESCRIPTION
### Motivation and Context
Creating a docker image allows us to easily bring up our project with the other services it needs to run with.
### What has changed
- Added Dockerfile and docker-compose.yml file

### How to test?
- As the docker image isn't on dockerhub yet, you'll have to build it using `docker build -t sdc-responses-dashboard .`. Once the image has been built, you should be able to bring up the service using `docker-compose up -d`.

### Links
[Trello](https://trello.com/c/AvSfWzbk)

### Checklist

* [x] STATIC_ASSETS_VERSION updated.