### PR TITLE
Only load surveys with valid collection exercises

### DIFF
--- a/app/survey_metadata.py
+++ b/app/survey_metadata.py
@@ -16,7 +16,7 @@ def map_surveys_to_collection_exercises(surveys, collection_exercises) -> list:
             'surveyRef': survey['surveyRef'],
             'surveyType': survey['surveyType'],
             'collectionExercises': []
-        } for survey in surveys
+        } for survey in surveys if survey['id'] in [ex['surveyId'] for ex in collection_exercises]
     }
 
     for collection_exercise in collection_exercises:

--- a/tests/app/test_survey_metadata.py
+++ b/tests/app/test_survey_metadata.py
@@ -44,14 +44,6 @@ class TestSurveyMetadata(AppContextTestCase):
                 ]
             },
             {
-                'surveyId': '04dbb407-4438-4f89-acc4-53445d75330c',
-                'shortName': 'AOFDI',
-                'surveyType': 'Business',
-                'longName': 'Annual Outward Foreign Direct Investment Survey',
-                'surveyRef': '063',
-                'collectionExercises': []
-            },
-            {
                 'surveyId': '04dbb407-4438-4f89-acc4-53445d753111',
                 'shortName': 'QBS',
                 'surveyType': 'Business',
@@ -66,14 +58,6 @@ class TestSurveyMetadata(AppContextTestCase):
                         'scheduledReturnDateTime': '2017-10-06T00:00:00.000Z',
                     }
                 ]
-            },
-            {
-                'surveyId': '56dbb407-4438-4f89-acc4-53445d753111',
-                'shortName': 'LMS',
-                'longName': 'Labour Market Survey',
-                'surveyRef': '999',
-                'surveyType': 'Social',
-                'collectionExercises': []
             }
         ]
 
@@ -148,14 +132,6 @@ class TestSurveyMetadata(AppContextTestCase):
                         'scheduledReturnDateTime': '2017-10-06T00:00:00.000Z'
                     }
                 ]
-            },
-            {
-                'surveyId': '04dbb407-4438-4f89-acc4-53445d75330c',
-                'shortName': 'AOFDI',
-                'longName': 'Annual Outward Foreign Direct Investment Survey',
-                'surveyRef': '063',
-                'surveyType': 'Business',
-                'collectionExercises': []
             },
             {
                 'surveyId': '04dbb407-4438-4f89-acc4-53445d753111',

--- a/tests/app/views/test_dashboard.py
+++ b/tests/app/views/test_dashboard.py
@@ -41,8 +41,9 @@ class TestDashboardView(AppContextTestCase):
         self.assertIn(b'Reference', response.data)
         self.assertIn(b'BRES', response.data)
         self.assertIn(b'Business Register and Employment Survey', response.data)
-        self.assertIn(b'AOFDI', response.data)
-        self.assertIn(b'Annual Outward Foreign Direct Investment Survey', response.data)
+        self.assertIn(b'QBS', response.data)
+        self.assertIn(b'Quarterly Business Survey', response.data)
+        self.assertNotIn(b'AOFDI', response.data)
 
     @responses.activate
     def test_dashboard_report_fails_gracefully(self):


### PR DESCRIPTION
### Motivation and Context
We were passing all surveys to the view even when they did not have any collection exercises.

Since the user can only choose surveys that have at least 1 collection exercise, there is no need to send all surveys to the view.

### What has changed
Added an `if` to ensure the survey id must be in list of collection exercises.

### How to test?
- App works as expected.
- No change to functionality.
- Only surveys with collection is loaded in the view.

### Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->

### Checklist

* [x] STATIC_ASSETS_VERSION updated.