### PR TITLE
Upgrade packages to fix Git security vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,11 +44,11 @@
     "prettier": "^1.15.3"
   },
   "dependencies": {
-    "bootstrap": "3.3.7",
+    "bootstrap": "3.4.1",
     "datatables.net": "1.10.19",
     "datatables.net-scroller": "1.5.1",
     "domready": "^1.0.8",
-    "jquery": "3.3.1",
+    "jquery": "3.4.1",
     "jquery-ui": "1.12.1",
     "moment": "^2.23.0",
     "pace-js": "1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1008,10 +1008,10 @@ bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.4.0:
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.8.tgz#2cde09eb5ee341f484746bb0309b3253b1b1442f"
   integrity sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==
 
-bootstrap@3.3.7:
-  version "3.3.7"
-  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-3.3.7.tgz#5a389394549f23330875a3b150656574f8a9eb71"
-  integrity sha1-WjiTlFSfIzMIdaOxUGVldPip63E=
+bootstrap@3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-3.4.1.tgz#c3a347d419e289ad11f4033e3c4132b87c081d72"
+  integrity sha512-yN5oZVmRCwe5aKwzRj6736nSmKDX7pLYwsXiCj/EYmo16hODaBiT4En5btW/jhBF/seV+XMx3aYwukYC3A49DA==
 
 brace-expansion@^1.1.7:
   version "1.1.11"
@@ -3205,7 +3205,12 @@ jquery-ui@1.12.1:
   resolved "https://registry.yarnpkg.com/jquery-ui/-/jquery-ui-1.12.1.tgz#bcb4045c8dd0539c134bc1488cdd3e768a7a9e51"
   integrity sha1-vLQEXI3QU5wTS8FIjN0+dop6nlE=
 
-jquery@3.3.1, jquery@>=1.7:
+jquery@3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.4.1.tgz#714f1f8d9dde4bdfa55764ba37ef214630d80ef2"
+  integrity sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==
+
+jquery@>=1.7:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.3.1.tgz#958ce29e81c9790f31be7792df5d4d95fc57fbca"
   integrity sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg==


### PR DESCRIPTION
### Motivation and Context
Upgraded 2 packages following Git security warnings

### What has changed
Upgraded jquery and bootstrap packages to fix Git security vulnerabilities.  Note - Jquery has been updated to the latest version but bootstrap has only been updated to 
3.4.1 (which is still the minimum release required to fix the security issue).  This is because the next version is a major release that contains significant changes which breaks the dashboard.  A card has been raised to look into upgrading to the newest version before we're forced to.

### How to test?
- Run `make compile` and `make build` to compile the packages.
- Run against the mock services (set the required env vars and run `make mock_services` - see README)
- Test that all navigation still works

### Links
https://trello.com/c/zvqqEyrU