### PR TITLE
Change date from MPS to Go Live

### DIFF
--- a/app/static/assets/js/datatables.js
+++ b/app/static/assets/js/datatables.js
@@ -118,7 +118,7 @@ const initialiseCollexDataTable = () =>
         width: "50%"
       },
       {
-        data: "scheduledExecutionDateTime",
+        data: "scheduledStartDateTime",
         defaultContent: "No go live provided",
         title: "Go Live",
         width: "25%",

--- a/app/survey_metadata.py
+++ b/app/survey_metadata.py
@@ -27,7 +27,8 @@ def map_surveys_to_collection_exercises(surveys, collection_exercises) -> list:
                     'userDescription': collection_exercise['userDescription'],
                     'exerciseRef': collection_exercise['exerciseRef'],
                     'scheduledExecutionDateTime': collection_exercise['scheduledExecutionDateTime'],
-                    'scheduledReturnDateTime': collection_exercise['scheduledReturnDateTime']
+                    'scheduledReturnDateTime': collection_exercise['scheduledReturnDateTime'],
+                    'scheduledStartDateTime': collection_exercise['scheduledStartDateTime']
                 }
             )
         except KeyError as e:
@@ -53,6 +54,7 @@ def map_collection_exercise_id_to_survey_id(surveys_to_collection_exercises) -> 
                 'userDescription': collection_exercise['userDescription'],
                 'scheduledExecutionDateTime': collection_exercise['scheduledExecutionDateTime'],
                 'scheduledReturnDateTime': collection_exercise['scheduledReturnDateTime'],
+                'scheduledStartDateTime': collection_exercise['scheduledStartDateTime'],
                 'exerciseRef': collection_exercise['exerciseRef']
             }
 

--- a/config.py
+++ b/config.py
@@ -26,7 +26,7 @@ class Config:
     AUTH_PASSWORD = os.getenv('AUTH_PASSWORD')
     LOGGING_LEVEL = os.getenv('LOGGING_LEVEL', 'INFO')
     LOGGING_JSON_INDENT = os.getenv('LOGGING_JSON_INDENT')
-    STATIC_ASSETS_VERSION = os.getenv('STATIC_ASSETS_VERSION', '1.1.3')  # Defaulted until releases
+    STATIC_ASSETS_VERSION = os.getenv('STATIC_ASSETS_VERSION', '1.1.4')  # Defaulted until releases
 
 
 class DevelopmentConfig(Config):

--- a/tests/app/test_survey_metadata.py
+++ b/tests/app/test_survey_metadata.py
@@ -33,6 +33,7 @@ class TestSurveyMetadata(AppContextTestCase):
                         'exerciseRef': '201712',
                         'scheduledExecutionDateTime': '2017-09-10T23:00:00.000Z',
                         'scheduledReturnDateTime': '2017-10-06T00:00:00.000Z',
+                        'scheduledStartDateTime': '2017-09-11T23:00:00.000Z'
                     },
                     {
                         'collectionExerciseId': '24fb3e68-4dca-46db-bf49-04b84e07e77c',
@@ -40,6 +41,7 @@ class TestSurveyMetadata(AppContextTestCase):
                         'exerciseRef': '201801',
                         'scheduledExecutionDateTime': '2017-09-10T23:00:00.000Z',
                         'scheduledReturnDateTime': '2017-10-06T00:00:00.000Z',
+                        'scheduledStartDateTime': '2017-09-11T23:00:00.000Z'
                     }
                 ]
             },
@@ -56,6 +58,7 @@ class TestSurveyMetadata(AppContextTestCase):
                         'exerciseRef': '201812',
                         'scheduledExecutionDateTime': '2017-09-10T23:00:00.000Z',
                         'scheduledReturnDateTime': '2017-10-06T00:00:00.000Z',
+                        'scheduledStartDateTime': '2017-09-11T23:00:00.000Z'
                     }
                 ]
             }
@@ -75,6 +78,7 @@ class TestSurveyMetadata(AppContextTestCase):
                     'longName': 'Quarterly Business Survey',
                     'scheduledExecutionDateTime': '2017-09-10T23:00:00.000Z',
                     'scheduledReturnDateTime': '2017-10-06T00:00:00.000Z',
+                    'scheduledStartDateTime': '2017-09-11T23:00:00.000Z',
                     'shortName': 'QBS',
                     'surveyId': '04dbb407-4438-4f89-acc4-53445d753111',
                     'surveyType': 'Business',
@@ -86,6 +90,7 @@ class TestSurveyMetadata(AppContextTestCase):
                     'longName': 'Business Register and Employment Survey',
                     'scheduledExecutionDateTime': '2017-09-10T23:00:00.000Z',
                     'scheduledReturnDateTime': '2017-10-06T00:00:00.000Z',
+                    'scheduledStartDateTime': '2017-09-11T23:00:00.000Z',
                     'shortName': 'BRES',
                     'surveyId': 'cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87',
                     'surveyType': 'Business',
@@ -96,6 +101,7 @@ class TestSurveyMetadata(AppContextTestCase):
                     'longName': 'Business Register and Employment Survey',
                     'scheduledExecutionDateTime': '2017-09-10T23:00:00.000Z',
                     'scheduledReturnDateTime': '2017-10-06T00:00:00.000Z',
+                    'scheduledStartDateTime': '2017-09-11T23:00:00.000Z',
                     'shortName': 'BRES',
                     'surveyId': 'cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87',
                     'surveyType': 'Business',
@@ -128,7 +134,8 @@ class TestSurveyMetadata(AppContextTestCase):
                         'userDescription': 'January 2018',
                         'exerciseRef': '201801',
                         'scheduledExecutionDateTime': '2017-09-10T23:00:00.000Z',
-                        'scheduledReturnDateTime': '2017-10-06T00:00:00.000Z'
+                        'scheduledReturnDateTime': '2017-10-06T00:00:00.000Z',
+                        'scheduledStartDateTime': '2017-09-11T23:00:00.000Z'
                     }
                 ]
             },
@@ -144,7 +151,8 @@ class TestSurveyMetadata(AppContextTestCase):
                         'userDescription': 'Quarterly Business Survey',
                         'exerciseRef': '201812',
                         'scheduledExecutionDateTime': '2017-09-10T23:00:00.000Z',
-                        'scheduledReturnDateTime': '2017-10-06T00:00:00.000Z'
+                        'scheduledReturnDateTime': '2017-10-06T00:00:00.000Z',
+                        'scheduledStartDateTime': '2017-09-11T23:00:00.000Z'
                     }
                 ]
             }
@@ -160,6 +168,7 @@ class TestSurveyMetadata(AppContextTestCase):
                  'surveyId': '04dbb407-4438-4f89-acc4-53445d753111',
                  'scheduledExecutionDateTime': '2017-09-10T23:00:00.000Z',
                  'scheduledReturnDateTime': '2017-10-06T00:00:00.000Z',
+                 'scheduledStartDateTime': '2017-09-11T23:00:00.000Z',
                  'userDescription': 'Quarterly Business Survey'},
             '24fb3e68-4dca-46db-bf49-04b84e07e77c':
                 {'exerciseRef': '201801',
@@ -170,6 +179,7 @@ class TestSurveyMetadata(AppContextTestCase):
                  'surveyId': 'cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87',
                  'scheduledExecutionDateTime': '2017-09-10T23:00:00.000Z',
                  'scheduledReturnDateTime': '2017-10-06T00:00:00.000Z',
+                 'scheduledStartDateTime': '2017-09-11T23:00:00.000Z',
                  'userDescription': 'January 2018'}}
 
         self.assertEqual(expected_surveys,


### PR DESCRIPTION
### Motivation and Context
The Go Live column on the dashboard uses the MPS date rather than the Go Live date. This fixes that.

### Checklist

* [x] STATIC_ASSETS_VERSION updated.