### PR TITLE
revert apiVersion to v1beta1

### DIFF
--- a/_infra/helm/responses-dashboard/Chart.yaml
+++ b/_infra/helm/responses-dashboard/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.0.7
+appVersion: 2.0.8

--- a/_infra/helm/responses-dashboard/templates/ManagesCertificate.yaml
+++ b/_infra/helm/responses-dashboard/templates/ManagesCertificate.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingress.enabled }}
-apiVersion: networking.gke.io/v1
+apiVersion: networking.gke.io/v1beta1
 kind: ManagedCertificate
 metadata:
   name: {{ .Values.ingress.certName }}

--- a/_infra/helm/responses-dashboard/templates/ingress.yaml
+++ b/_infra/helm/responses-dashboard/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingress.enabled }}
-apiVersion: networking.k8s.io/v1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ .Chart.Name }}-ingress


### PR DESCRIPTION
I changed versions on the wrong manifests in error following a PR on another repo which made the same error. this requires reverting