### PR TITLE
Docker tag latest at the same time as the release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,8 +7,6 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
-    paths-ignore:
-      - _infra/helm/responses-dashboard/Chart.yaml
 
 env:
   IMAGE: responses-dashboard
@@ -139,12 +137,13 @@ jobs:
       - name: Build Release Image
         if: github.ref == 'refs/heads/main'
         run: |
-          docker build -f _infra/docker/Dockerfile -t "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$IMAGE":${{ steps.release.outputs.version }} .
+          docker build -f _infra/docker/Dockerfile -t "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$IMAGE":latest -t "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$IMAGE":${{ steps.release.outputs.version }} .
       - name: Push Release image
         if: github.ref == 'refs/heads/main'
         run: |
           docker push "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$IMAGE":${{ steps.release.outputs.version }}
-      
+          docker push "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$IMAGE":latest
+
       - name: Publish Charts
         if: github.ref == 'refs/heads/main'
         run: |

--- a/_infra/helm/responses-dashboard/Chart.yaml
+++ b/_infra/helm/responses-dashboard/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.0.13
+appVersion: 2.0.14


### PR DESCRIPTION
# What and why?
During the release step tag the generated docker image as both the release version and latest.


# How to test?

# Trello
