### PR TITLE
Fix helm chart version

### DIFF
--- a/_infra/helm/responses-dashboard/Chart.yaml
+++ b/_infra/helm/responses-dashboard/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.18
+version: 2.0.19
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.0.18
+appVersion: 2.0.19

--- a/_infra/helm/responses-dashboard/templates/deployment.yaml
+++ b/_infra/helm/responses-dashboard/templates/deployment.yaml
@@ -26,7 +26,7 @@ spec:
           {{- if eq .Values.image.tag "latest" }}
           image: "{{ .Values.image.name}}/{{ .Chart.Name }}:{{ .Chart.AppVersion }}"
           {{- else }}
-          image: "{{ .Values.image.name}}/{{ .Chart.Name }}:{{ .Values.image.version }}"
+          image: "{{ .Values.image.name}}/{{ .Chart.Name }}:{{ .Values.image.tag }}"
           {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:


### PR DESCRIPTION
# What and why?

The helm chart was using .version instead of .tag and it was breaking the deployment.  This PR fixes it

# How to test?

# Trello
