### PR TITLE
Fix Go live date bug

### DIFF
--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     if: contains(github.event.comment.body, '/deploy')
     steps:
-      - uses: google-github-actions/setup-gcloud@master
+      - uses: google-github-actions/setup-gcloud@v0
         with:
           project_id: ${{ secrets.GOOGLE_PROJECT_ID }}
           service_account_key: ${{ secrets.GCR_KEY }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,7 @@ jobs:
           pipenv install --dev
       - name: Test
         run: make test
-      - uses: google-github-actions/setup-gcloud@master
+      - uses: google-github-actions/setup-gcloud@v0
         with:
           version: '270.0.0'
           service_account_key: ${{ secrets.GCR_KEY }}

--- a/_infra/helm/responses-dashboard/Chart.yaml
+++ b/_infra/helm/responses-dashboard/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.20
+version: 2.0.21
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.0.20
+appVersion: 2.0.21

--- a/app/static/assets/js/datatables.js
+++ b/app/static/assets/js/datatables.js
@@ -118,14 +118,14 @@ const initialiseCollexDataTable = () =>
         width: "50%"
       },
       {
-        data: "scheduledStartDateTime",
+        data: "exerciseGoLiveDate",
         defaultContent: "No go live provided",
         title: "Go Live",
         width: "25%",
         render: customDateRenderer
       },
       {
-        data: "scheduledReturnDateTime",
+        data: "exerciseReturnDate",
         defaultContent: "No return by date provided",
         title: "Return By Date",
         width: "25%",

--- a/app/survey_metadata.py
+++ b/app/survey_metadata.py
@@ -1,9 +1,10 @@
+from typing import Mapping, Optional
+
 from structlog import get_logger
 
 from app.controllers.collection_exercise_controller import get_collection_exercise_list
 from app.controllers.survey_controller import get_survey_list
 from app.exceptions import UnknownSurveyError
-from typing import Optional, Mapping
 
 logger = get_logger()
 

--- a/tests/app/test_survey_metadata.py
+++ b/tests/app/test_survey_metadata.py
@@ -90,7 +90,6 @@ class TestSurveyMetadata(AppContextTestCase):
                 "userDescription": "December 2017",
                 "exerciseReturnDate": "2017-10-06T00:00:00.000Z",
                 "exerciseGoLiveDate": "2017-09-11T24:00:00.000Z",
-
             },
             "24fb3e68-4dca-46db-bf49-04b84e07e77c": {
                 "exerciseRef": "201801",

--- a/tests/app/test_survey_metadata.py
+++ b/tests/app/test_survey_metadata.py
@@ -6,6 +6,7 @@ import responses
 from app.exceptions import UnknownSurveyError
 from app.survey_metadata import (
     fetch_survey_and_collection_exercise_metadata,
+    get_event_timestamp_for_tag,
     map_collection_exercise_id_to_survey_id,
     map_surveys_to_collection_exercises,
 )
@@ -34,17 +35,15 @@ class TestSurveyMetadata(AppContextTestCase):
                         "collectionExerciseId": "14fb3e68-4dca-46db-bf49-04b84e07e77c",
                         "userDescription": "December 2017",
                         "exerciseRef": "201712",
-                        "scheduledExecutionDateTime": "2017-09-10T23:00:00.000Z",
-                        "scheduledReturnDateTime": "2017-10-06T00:00:00.000Z",
-                        "scheduledStartDateTime": "2017-09-11T23:00:00.000Z",
+                        "exerciseGoLiveDate": "2017-09-11T24:00:00.000Z",
+                        "exerciseReturnDate": "2017-10-06T00:00:00.000Z",
                     },
                     {
                         "collectionExerciseId": "24fb3e68-4dca-46db-bf49-04b84e07e77c",
                         "userDescription": "January 2018",
                         "exerciseRef": "201801",
-                        "scheduledExecutionDateTime": "2017-09-10T23:00:00.000Z",
-                        "scheduledReturnDateTime": "2017-10-06T00:00:00.000Z",
-                        "scheduledStartDateTime": "2017-09-11T23:00:00.000Z",
+                        "exerciseGoLiveDate": "2017-09-11T24:00:00.000Z",
+                        "exerciseReturnDate": "2017-10-06T00:00:00.000Z",
                     },
                 ],
             },
@@ -59,9 +58,8 @@ class TestSurveyMetadata(AppContextTestCase):
                         "collectionExerciseId": "14fb3e68-4dca-46db-bf49-04b84e07e777",
                         "userDescription": "Quarterly Business Survey",
                         "exerciseRef": "201812",
-                        "scheduledExecutionDateTime": "2017-09-10T23:00:00.000Z",
-                        "scheduledReturnDateTime": "2017-10-06T00:00:00.000Z",
-                        "scheduledStartDateTime": "2017-09-11T23:00:00.000Z",
+                        "exerciseGoLiveDate": "2017-09-11T24:00:00.000Z",
+                        "exerciseReturnDate": "2017-10-06T00:00:00.000Z",
                     }
                 ],
             },
@@ -76,35 +74,33 @@ class TestSurveyMetadata(AppContextTestCase):
             "14fb3e68-4dca-46db-bf49-04b84e07e777": {
                 "exerciseRef": "201812",
                 "longName": "Quarterly Business Survey",
-                "scheduledExecutionDateTime": "2017-09-10T23:00:00.000Z",
-                "scheduledReturnDateTime": "2017-10-06T00:00:00.000Z",
-                "scheduledStartDateTime": "2017-09-11T23:00:00.000Z",
                 "shortName": "QBS",
                 "surveyId": "04dbb407-4438-4f89-acc4-53445d753111",
                 "surveyType": "Business",
-                "userDescription": "Quarterly " "Business Survey",
+                "userDescription": "Quarterly Business Survey",
+                "exerciseGoLiveDate": "2017-09-11T24:00:00.000Z",
+                "exerciseReturnDate": "2017-10-06T00:00:00.000Z",
             },
             "14fb3e68-4dca-46db-bf49-04b84e07e77c": {
                 "exerciseRef": "201712",
                 "longName": "Business Register and Employment Survey",
-                "scheduledExecutionDateTime": "2017-09-10T23:00:00.000Z",
-                "scheduledReturnDateTime": "2017-10-06T00:00:00.000Z",
-                "scheduledStartDateTime": "2017-09-11T23:00:00.000Z",
                 "shortName": "BRES",
                 "surveyId": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87",
                 "surveyType": "Business",
                 "userDescription": "December 2017",
+                "exerciseReturnDate": "2017-10-06T00:00:00.000Z",
+                "exerciseGoLiveDate": "2017-09-11T24:00:00.000Z",
+
             },
             "24fb3e68-4dca-46db-bf49-04b84e07e77c": {
                 "exerciseRef": "201801",
                 "longName": "Business Register and Employment Survey",
-                "scheduledExecutionDateTime": "2017-09-10T23:00:00.000Z",
-                "scheduledReturnDateTime": "2017-10-06T00:00:00.000Z",
-                "scheduledStartDateTime": "2017-09-11T23:00:00.000Z",
                 "shortName": "BRES",
                 "surveyId": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87",
                 "surveyType": "Business",
                 "userDescription": "January 2018",
+                "exerciseGoLiveDate": "2017-09-11T24:00:00.000Z",
+                "exerciseReturnDate": "2017-10-06T00:00:00.000Z",
             },
         }
 
@@ -135,9 +131,8 @@ class TestSurveyMetadata(AppContextTestCase):
                         "collectionExerciseId": "24fb3e68-4dca-46db-bf49-04b84e07e77c",
                         "userDescription": "January 2018",
                         "exerciseRef": "201801",
-                        "scheduledExecutionDateTime": "2017-09-10T23:00:00.000Z",
-                        "scheduledReturnDateTime": "2017-10-06T00:00:00.000Z",
-                        "scheduledStartDateTime": "2017-09-11T23:00:00.000Z",
+                        "exerciseGoLiveDate": "2017-09-11T24:00:00.000Z",
+                        "exerciseReturnDate": "2017-10-06T00:00:00.000Z",
                     }
                 ],
             },
@@ -152,9 +147,8 @@ class TestSurveyMetadata(AppContextTestCase):
                         "collectionExerciseId": "14fb3e68-4dca-46db-bf49-04b84e07e777",
                         "userDescription": "Quarterly Business Survey",
                         "exerciseRef": "201812",
-                        "scheduledExecutionDateTime": "2017-09-10T23:00:00.000Z",
-                        "scheduledReturnDateTime": "2017-10-06T00:00:00.000Z",
-                        "scheduledStartDateTime": "2017-09-11T23:00:00.000Z",
+                        "exerciseGoLiveDate": "2017-09-11T24:00:00.000Z",
+                        "exerciseReturnDate": "2017-10-06T00:00:00.000Z",
                     }
                 ],
             },
@@ -163,25 +157,23 @@ class TestSurveyMetadata(AppContextTestCase):
         expected_collection_exercises = {
             "14fb3e68-4dca-46db-bf49-04b84e07e777": {
                 "exerciseRef": "201812",
-                "longName": "Quarterly Business " "Survey",
+                "longName": "Quarterly Business Survey",
                 "shortName": "QBS",
                 "surveyType": "Business",
                 "surveyId": "04dbb407-4438-4f89-acc4-53445d753111",
-                "scheduledExecutionDateTime": "2017-09-10T23:00:00.000Z",
-                "scheduledReturnDateTime": "2017-10-06T00:00:00.000Z",
-                "scheduledStartDateTime": "2017-09-11T23:00:00.000Z",
                 "userDescription": "Quarterly Business Survey",
+                "exerciseGoLiveDate": "2017-09-11T24:00:00.000Z",
+                "exerciseReturnDate": "2017-10-06T00:00:00.000Z",
             },
             "24fb3e68-4dca-46db-bf49-04b84e07e77c": {
                 "exerciseRef": "201801",
-                "longName": "Business Register and " "Employment Survey",
+                "longName": "Business Register and Employment Survey",
                 "shortName": "BRES",
                 "surveyType": "Business",
                 "surveyId": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87",
-                "scheduledExecutionDateTime": "2017-09-10T23:00:00.000Z",
-                "scheduledReturnDateTime": "2017-10-06T00:00:00.000Z",
-                "scheduledStartDateTime": "2017-09-11T23:00:00.000Z",
                 "userDescription": "January 2018",
+                "exerciseGoLiveDate": "2017-09-11T24:00:00.000Z",
+                "exerciseReturnDate": "2017-10-06T00:00:00.000Z",
             },
         }
 
@@ -199,7 +191,9 @@ class TestSurveyMetadata(AppContextTestCase):
 
         for survey in surveys:
             self.assertEqual(
-                survey["surveyType"], "Business", 'Found survey type not equal to "Business" in surveys list'
+                survey["surveyType"],
+                "Business",
+                'Found survey type not equal to "Business" in surveys list',
             )
 
         for collection_exercise in collection_exercises.values():
@@ -209,11 +203,34 @@ class TestSurveyMetadata(AppContextTestCase):
                 'Found survey type not equal to "Business" in collection exercise map',
             )
 
+    def test_get_event_timestamp_for_tag(self):
+        timestamp = "2017-09-11T24:00:00.000Z"
+        event_timestamp = get_event_timestamp_for_tag([{"tag": "go_live", "timestamp": timestamp}], "go_live")
+        self.assertEqual(event_timestamp, timestamp)
+
+    def test_get_event_timestamp_for_tag_missing_event(self):
+        event_timestamp = get_event_timestamp_for_tag(
+            [{"tag": "return_by", "timestamp": "2017-10-11T24:00:00.000Z"}], "go_live"
+        )
+        self.assertEqual(event_timestamp, None)
+
+    def test_get_event_timestamp_for_tag_empty_events(self):
+        event_timestamp = get_event_timestamp_for_tag({}, "go_live")
+        self.assertEqual(event_timestamp, None)
+
+    def test_get_event_timestamp_for_tag_none_events(self):
+        event_timestamp = get_event_timestamp_for_tag(None, "go_live")
+        self.assertEqual(event_timestamp, None)
+
     def fetch_mock_survey_and_collection_exercises_response(self):
         # Requires @responses.activate
         with self.app.app_context():
             # Mock the survey and collection exercise services
-            responses.add(responses.GET, self.app.config["SURVEY_URL"] + "/surveys", json=self.surveys_response)
+            responses.add(
+                responses.GET,
+                self.app.config["SURVEY_URL"] + "/surveys",
+                json=self.surveys_response,
+            )
             responses.add(
                 responses.GET,
                 self.app.config["COLLECTION_EXERCISE_URL"] + "/collectionexercises",

--- a/tests/test_data/get_collection_exercises_response.json
+++ b/tests/test_data/get_collection_exercises_response.json
@@ -28,7 +28,23 @@
     "created": null,
     "updated": null,
     "deleted": false,
-    "validationErrors": null
+    "validationErrors": null,
+    "events":[
+      {
+         "id":"383c2f3f-ead7-46b1-82c1-2c3c0938ee9e",
+         "collectionExerciseId":"2f3275bd-c433-4a99-8771-d331e7508d9d",
+         "tag":"go_live",
+         "timestamp":"2017-09-11T24:00:00.000Z",
+         "eventStatus":"SCHEDULED"
+      },
+      {
+         "id":"eb9adff0-c596-4047-b514-52ee5f7da063",
+         "collectionExerciseId":"2f3275bd-c433-4a99-8771-d331e7508d9d",
+         "tag":"return_by",
+         "timestamp":"2017-10-06T00:00:00.000Z",
+         "eventStatus":"SCHEDULED"
+      }
+   ]
   },
   {
     "id": "24fb3e68-4dca-46db-bf49-04b84e07e77c",
@@ -59,7 +75,23 @@
     "created": null,
     "updated": null,
     "deleted": false,
-    "validationErrors": null
+    "validationErrors": null,
+        "events":[
+      {
+         "id":"383c2f3f-ead7-46b1-82c1-2c3c0938ee9e",
+         "collectionExerciseId":"2f3275bd-c433-4a99-8771-d331e7508d9d",
+         "tag":"go_live",
+         "timestamp":"2017-09-11T24:00:00.000Z",
+         "eventStatus":"SCHEDULED"
+      },
+      {
+         "id":"eb9adff0-c596-4047-b514-52ee5f7da063",
+         "collectionExerciseId":"2f3275bd-c433-4a99-8771-d331e7508d9d",
+         "tag":"return_by",
+         "timestamp":"2017-10-06T00:00:00.000Z",
+         "eventStatus":"SCHEDULED"
+      }
+   ]
   },
   {
     "id": "14fb3e68-4dca-46db-bf49-04b84e07e777",
@@ -90,6 +122,22 @@
     "created": null,
     "updated": null,
     "deleted": false,
-    "validationErrors": null
+    "validationErrors": null,
+    "events":[
+      {
+         "id":"383c2f3f-ead7-46b1-82c1-2c3c0938ee9e",
+         "collectionExerciseId":"2f3275bd-c433-4a99-8771-d331e7508d9d",
+         "tag":"go_live",
+         "timestamp":"2017-09-11T24:00:00.000Z",
+         "eventStatus":"SCHEDULED"
+      },
+      {
+         "id":"eb9adff0-c596-4047-b514-52ee5f7da063",
+         "collectionExerciseId":"2f3275bd-c433-4a99-8771-d331e7508d9d",
+         "tag":"return_by",
+         "timestamp":"2017-10-06T00:00:00.000Z",
+         "eventStatus":"SCHEDULED"
+      }
+   ]
   }
 ]


### PR DESCRIPTION
# What and why?
The response dashboard is currently showing the MPS date in the Go live column. The problem was that the SQL was querying the wrong table, which doesn't hold the values for **go live** and **return by**, it should call from the events table. The endpoint in collection exercise was already returning all the information I needed, so I adjusted the value it used. 

N.B For consistency I also updated the return by as well, as although you can get that information from the original table it isn't explicit and is named differently. 

# How to test?
The best way is have all the other services running in GCP and port kill responses dashboard, running your own locally instead, using this branch. You can also push this change up to GCP as well, but I find you lose a bit of control. Once you have the services up and running, seed the data, (i.e create a collection exercise and make it live) now check the dashboard and make sure the values are current.


# Trello
https://trello.com/c/cbMNIns3/1720-bug-go-live-date-in-responses-dashboard-is-actually-displaying-the-mps-date-from-rops-ui