### PR TITLE
Update HPA to v2

### DIFF
--- a/_infra/helm/responses-dashboard/templates/hpa.yaml
+++ b/_infra/helm/responses-dashboard/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.autoscaling }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ .Chart.Name }}


### PR DESCRIPTION
# What and why?
Update autoscaling from v2beta2 to v2
# How to test?
The HPA change has already been proven here https://github.com/ONSdigital/ras-party/pull/389, but can be done again if required, just deploy via helm
# Trello
