### PR TITLE
RAS 964: Upgrade responses dashboard to Flask 3

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,4 +2,4 @@
 
 # How to test?
 
-# Trello
+# Jira

--- a/_infra/helm/responses-dashboard/Chart.yaml
+++ b/_infra/helm/responses-dashboard/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.30
+version: 2.0.31
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.0.30
+appVersion: 2.0.31

--- a/app/setup.py
+++ b/app/setup.py
@@ -102,6 +102,7 @@ def _configure_logger(level="INFO", indent=None):
         renderer_processor,
     ]
     structlog.configure(
+        context_class=dict,
         logger_factory=LoggerFactory(),
         processors=processors,
         cache_logger_on_first_use=True,

--- a/app/setup.py
+++ b/app/setup.py
@@ -103,7 +103,7 @@ def _configure_logger(level="INFO", indent=None):
         renderer_processor,
     ]
     structlog.configure(
-        context_class=wrap_dict(dict),
+        # context_class=wrap_dict(dict),
         logger_factory=LoggerFactory(),
         processors=processors,
         cache_logger_on_first_use=True,

--- a/app/setup.py
+++ b/app/setup.py
@@ -13,7 +13,6 @@ from structlog.stdlib import (
     add_logger_name,
     filter_by_level,
 )
-from structlog.threadlocal import wrap_dict
 
 import config
 from app.api.health import health_blueprint
@@ -103,7 +102,6 @@ def _configure_logger(level="INFO", indent=None):
         renderer_processor,
     ]
     structlog.configure(
-        # context_class=wrap_dict(dict),
         logger_factory=LoggerFactory(),
         processors=processors,
         cache_logger_on_first_use=True,


### PR DESCRIPTION
# What and why?
The structlog.threadlocal was found to be deprecated. The wrap_dict() is not needed. This ticket deals with removing this.

# How to test?
Run unit tests, acceptance tests and check in your dev env

# Jira
https://jira.ons.gov.uk/browse/RAS-926
https://jira.ons.gov.uk/browse/RAS-964