### PR TITLE
RAS-1003 Remove structlog.threadlocal

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           credentials_json: ${{ secrets.GCR_KEY }}
       - name: Setup Google Cloud SDK
-        uses: google-github-actions/setup-gcloud@v0
+        uses: google-github-actions/setup-gcloud@v2
       - run: |
           gcloud auth configure-docker
 
@@ -164,18 +164,11 @@ jobs:
           cp $IMAGE-${{ env.HELM_VERSION }}.tgz $IMAGE-latest.tgz
           gsutil cp $IMAGE-*.tgz gs://$ARTIFACT_BUCKET/$IMAGE/
 
-      - uses: actions/create-release@v1
+      - name: Publish Release
         if: github.ref == 'refs/heads/main'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ env.version }}
-          release_name: ${{ env.version }}
-          body: |
-            Automated release
-            ${{ env.version }}
-          draft: false
-          prerelease: false
+        run: gh release create ${{ env.version }} --title ${{ env.version }} --notes ${{ env.version }}
 
       - name: CD hook
         if: github.ref == 'refs/heads/main'

--- a/_infra/helm/responses-dashboard/Chart.yaml
+++ b/_infra/helm/responses-dashboard/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.30
+version: 2.0.32
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.0.30
+appVersion: 2.0.32

--- a/app/setup.py
+++ b/app/setup.py
@@ -6,14 +6,6 @@ import structlog
 from flask import Flask, current_app, url_for
 from flask_cors import CORS
 from structlog import wrap_logger
-from structlog.processors import JSONRenderer, TimeStamper, format_exc_info
-from structlog.stdlib import (
-    LoggerFactory,
-    add_log_level,
-    add_logger_name,
-    filter_by_level,
-)
-from structlog.threadlocal import wrap_dict
 
 import config
 from app.api.health import health_blueprint
@@ -75,37 +67,34 @@ def versioned_url_for(endpoint, **values):
     return url_for(endpoint, **values)
 
 
-def _configure_logger(level="INFO", indent=None):
-    logging.basicConfig(stream=sys.stdout, level=level, format="%(message)s")
-
-    try:
-        indent = int(os.getenv("LOGGING_JSON_INDENT") or indent)
-    except TypeError:
-        indent = None
-    except ValueError:
-        indent = None
-
-    def add_service(_, __, event_dict):
+def _configure_logger(log_level: str = "INFO") -> None:
+    def add_service(_, __, event_dict: dict) -> dict:
         """
         Add the service name to the event dict.
         """
         event_dict["service"] = os.getenv("NAME", "sdc-responses-dashboard")
         return event_dict
 
-    renderer_processor = JSONRenderer(indent=indent)
-    processors = [
-        add_log_level,
-        filter_by_level,
-        add_service,
-        format_exc_info,
-        add_logger_name,
-        TimeStamper(fmt="%Y-%m-%dT%H:%M%s", utc=True, key="created_at"),
-        renderer_processor,
-    ]
+    def add_severity_level(_, method_name: str, event_dict: dict) -> dict:
+        """
+        Adds the log level to the event dict.
+        """
+        event_dict["severity"] = method_name
+        return event_dict
+
+    logging.basicConfig(format="%(message)s", stream=sys.stdout, level=log_level)
+
     structlog.configure(
-        context_class=wrap_dict(dict),
-        logger_factory=LoggerFactory(),
-        processors=processors,
+        processors=[
+            structlog.contextvars.merge_contextvars,
+            add_severity_level,
+            add_service,
+            structlog.processors.format_exc_info,
+            structlog.processors.TimeStamper(fmt="%Y-%m-%dT%H:%M%s", utc=True, key="created_at"),
+            structlog.processors.JSONRenderer(indent=None),
+        ],
+        wrapper_class=structlog.make_filtering_bound_logger(logging.getLevelName(log_level)),
+        logger_factory=structlog.stdlib.LoggerFactory(),
         cache_logger_on_first_use=True,
     )
 

--- a/app/setup.py
+++ b/app/setup.py
@@ -82,6 +82,15 @@ def _configure_logger(log_level: str = "INFO") -> None:
         event_dict["severity"] = method_name
         return event_dict
 
+    def parse_exception(_, __, event_dict: dict) -> dict:
+        """
+        Formats the exception string in the event_dict.
+        """
+        exception = event_dict.get("exception")
+        if exception:
+            event_dict["exception"] = exception.replace('"', "'").split("\n")
+        return event_dict
+
     logging.basicConfig(format="%(message)s", stream=sys.stdout, level=log_level)
 
     structlog.configure(
@@ -89,6 +98,7 @@ def _configure_logger(log_level: str = "INFO") -> None:
             structlog.contextvars.merge_contextvars,
             add_severity_level,
             add_service,
+            parse_exception,
             structlog.processors.format_exc_info,
             structlog.processors.TimeStamper(fmt="%Y-%m-%dT%H:%M%s", utc=True, key="created_at"),
             structlog.processors.JSONRenderer(indent=None),


### PR DESCRIPTION
# What and why?
Update the logs to be thread safe. I have aligned them to our other services. Why we would punch out the logger name who knows, that has been removed

# How to test?
Deploy this PR and make sure the logs are coming out as expected you will need a CE with at least one respondent enrolled. http://localhost:8078/dashboard/

N.B I was getting back 404's from reporting (different repo) on mine for empty CEs or ones with just dummy rus (i.e 1111) that isn't connected to this PR, but the logs might have found an issue that wasn't shown before because of misconfigurations. A fix would need to be done in the reporting repo if there is a problem  


# Trello
