### PR TITLE
Sign ras-rm-pr-bot commits with GPG key

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,10 +76,28 @@ jobs:
         run: |
           git fetch --tags
           echo "tag=$(git describe --tags --abbrev=0)" >> $GITHUB_ENV
+      - name: Import BOT GPG key
+        run: echo $BOT_GPG_KEY | base64 --decode | gpg --batch --import
+        env:
+          BOT_GPG_KEY: ${{ secrets.BOT_GPG_KEY }}
+      - name: Prepare gpg CLI signing step
+        run: |
+          rm -rf /tmp/gpg.sh
+          echo '#!/bin/bash' >> /tmp/gpg.sh
+          echo 'gpg --batch --pinentry-mode=loopback --passphrase $BOT_GPG_KEY_PASSPHRASE $@' >> /tmp/gpg.sh
+          chmod +x /tmp/gpg.sh
+      - name: Setup git
+        run: |
+          git config commit.gpgsign true
+          git config user.signingkey "${{ secrets.BOT_GPG_KEY_ID }}"
+          git config gpg.program /tmp/gpg.sh
+          git config user.name "${{ secrets.BOT_USERNAME }}"
+          git config user.email "${{ secrets.BOT_EMAIL }}"
       - name: update versions
         if: github.ref != 'refs/heads/main'
         env:
           GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
+          BOT_GPG_KEY_PASSPHRASE: ${{ secrets.BOT_GPG_KEY_PASSPHRASE }}
           COMMIT_MSG: |
             auto patch increment
         shell: bash
@@ -99,8 +117,6 @@ jobs:
             NEW_CHART_VERSION="version: $(echo ${{ env.tag }} | sed -e "s/[0-9]\{1,3\}/$NEW_PATCH/3")"
             sed -i -e "s/appVersion: .*/$NEW_APP_VERSION/g" $CHART_DIRECTORY/Chart.yaml
             sed -i -e "s/version: .*/$NEW_CHART_VERSION/g" $CHART_DIRECTORY/Chart.yaml
-            git config user.name "ras-rm-pr-bot"
-            git config user.email "${{ secrets.BOT_EMAIL }}"
             git remote set-url origin https://ras-rm-pr-bot:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
             git remote update
             git fetch
@@ -114,8 +130,6 @@ jobs:
               NEW_CHART_VERSION="version: $APP_VERSION"
               echo "replacing version with $NEW_CHART_VERSION"
               sed -i -e "s/version: .*/$NEW_CHART_VERSION/g" $CHART_DIRECTORY/Chart.yaml
-              git config user.name "ras-rm-pr-bot"
-              git config user.email "${{ secrets.BOT_EMAIL }}"
               git remote set-url origin https://ras-rm-pr-bot:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
               git remote update
               git fetch
@@ -135,7 +149,7 @@ jobs:
         shell: bash
         run: |
           echo "version=$(grep -E "appVersion:\s+" $CHART_DIRECTORY/Chart.yaml | cut -d" " -f2 | sed -r 's/"//g')" >> $GITHUB_ENV
-    
+
       - name: package helm
         run: |
           echo HELM_VERSION=$(grep -E "version:\s+" $CHART_DIRECTORY/Chart.yaml | cut -d" " -f2 | sed -r 's/"//g') >> $GITHUB_ENV

--- a/Makefile
+++ b/Makefile
@@ -9,13 +9,13 @@ build:
 	pipenv install --dev
 
 lint:
-	pipenv check
+	pipenv check --ignore=70612 --ignore=70624
 	pipenv run isort .
 	pipenv run black --line-length 120 .
 	pipenv run flake8
 
 lint-check:
-	pipenv check
+	pipenv check --ignore=70612 --ignore=70624
 	pipenv run isort --check-only .
 	pipenv run black --line-length 120 --check .
 	pipenv run flake8

--- a/_infra/helm/responses-dashboard/Chart.yaml
+++ b/_infra/helm/responses-dashboard/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.37
+version: 2.0.38
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.0.37
+appVersion: 2.0.38


### PR DESCRIPTION
# What and why?

The ras-rm-pr-bot commits that bump versions are not verified. This means we cannot enforce signed commits on the main branch.

This PR introduces a method of signing the BOT commits.

It uses a GPG signing key which is passphrase protected, stored as Github Actions secrets. It does not expose the key or passphrase in the Github Actions output.

Existing BOT secrets
```
BOT_EMAIL
BOT_TOKEN
BOT_USERNAME
```
New BOT secrets
```
BOT_GPG_KEY
BOT_GPG_KEY_ID
BOT_GPG_KEY_PASSPHRASE
```
Ensure BOT commits are signed and verified, and that the secrets aren't exposed. The build workflow for this PR should see the following successful steps
```
Import BOT GPG key
Prepare gpg CLI signing step
Setup git
```
Before the original `update versions` step successfully bumps the Chart.yaml version and creates a signed commit on this PR branch.