### PR TITLE
RAS-1154: Migrate Responses Dashboard from GCR to GAR

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,9 @@ env:
   REGISTRY_HOSTNAME: europe-west2-docker.pkg.dev
   HOST: ${{ secrets.GOOGLE_PROJECT_ID }}
   GAR_REPOSITORY: ${{ secrets.GAR_REPOSITORY }}
-  RELEASE_HOST: ${{ secrets.RELEASE_PROJECT_ID }}
+#  Temp override
+#  RELEASE_HOST: ${{ secrets.RELEASE_PROJECT_ID }}
+  RELEASE_HOST: ons-ci-rmrasbs
   CHART_DIRECTORY: _infra/helm/responses-dashboard
   SPINNAKER_TOPIC: ${{ secrets.SPINNAKER_TOPIC }}
   ARTIFACT_BUCKET: ${{ secrets.ARTIFACT_BUCKET }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,8 +12,7 @@ env:
   IMAGE: responses-dashboard
   REGISTRY_HOSTNAME: europe-west2-docker.pkg.dev
   HOST: ${{ secrets.GOOGLE_PROJECT_ID }}
-#  GAR_REPOSITORY: ${{ secrets.GAR_REPOSITORY }}
-  GAR_REPOSITORY: ons-ci-rmrasbs
+  GAR_REPOSITORY: ${{ secrets.GAR_REPOSITORY }}
   RELEASE_HOST: ${{ secrets.RELEASE_PROJECT_ID }}
   CHART_DIRECTORY: _infra/helm/responses-dashboard
   SPINNAKER_TOPIC: ${{ secrets.SPINNAKER_TOPIC }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,8 +10,9 @@ on:
 
 env:
   IMAGE: responses-dashboard
-  REGISTRY_HOSTNAME: eu.gcr.io
+  REGISTRY_HOSTNAME: europe-west2-docker.pkg.dev
   HOST: ${{ secrets.GOOGLE_PROJECT_ID }}
+  GAR_REPOSITORY: ${{ secrets.GAR_REPOSITORY }}
   RELEASE_HOST: ${{ secrets.RELEASE_PROJECT_ID }}
   CHART_DIRECTORY: _infra/helm/responses-dashboard
   SPINNAKER_TOPIC: ${{ secrets.SPINNAKER_TOPIC }}
@@ -49,7 +50,7 @@ jobs:
       - name: Setup Google Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
       - run: |
-          gcloud auth configure-docker
+          gcloud auth configure-docker europe-west2-docker.pkg.dev
 
       - name: pr docker tag
         if: github.ref != 'refs/heads/main'
@@ -62,11 +63,11 @@ jobs:
       - name: Build Docker Image
         if: github.ref != 'refs/heads/main'
         run: |
-          docker build -t "$REGISTRY_HOSTNAME"/"$HOST"/"$IMAGE":${{ env.pr_number }} -f _infra/docker/Dockerfile .
+          docker build -t "$REGISTRY_HOSTNAME"/"$HOST"/"$GAR_REPOSITORY"/"$IMAGE":${{ steps.tag.outputs.pr_number }} -f _infra/docker/Dockerfile .
       - name: Push dev image
         if: github.ref != 'refs/heads/main'
         run: |
-          docker push "$REGISTRY_HOSTNAME"/"$HOST"/"$IMAGE":${{ env.pr_number }}
+          docker push "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$GAR_REPOSITORY"/"$IMAGE":${{ env.pr_number }}
       - name: template helm
         run: |
           helm template $CHART_DIRECTORY
@@ -165,12 +166,12 @@ jobs:
       - name: Build Release Image
         if: github.ref == 'refs/heads/main'
         run: |
-          docker build -f _infra/docker/Dockerfile -t "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$IMAGE":latest -t "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$IMAGE":${{ env.version }} .
+          docker build -f _infra/docker/Dockerfile -t "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$GAR_REPOSITORY"/"$IMAGE":latest -t "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$GAR_REPOSITORY"/"$IMAGE":${{ steps.release.outputs.version }} .
       - name: Push Release image
         if: github.ref == 'refs/heads/main'
         run: |
-          docker push "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$IMAGE":${{ env.version }}
-          docker push "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$IMAGE":latest
+          docker push "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$GAR_REPOSITORY"/"$IMAGE":${{ env.version }}
+          docker push "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$GAR_REPOSITORY"/"$IMAGE":latest
 
       - name: Publish Charts
         if: github.ref == 'refs/heads/main'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,9 +13,7 @@ env:
   REGISTRY_HOSTNAME: europe-west2-docker.pkg.dev
   HOST: ${{ secrets.GOOGLE_PROJECT_ID }}
   GAR_REPOSITORY: ${{ secrets.GAR_REPOSITORY }}
-#  Temp override
-#  RELEASE_HOST: ${{ secrets.RELEASE_PROJECT_ID }}
-  RELEASE_HOST: ons-ci-rmrasbs
+  RELEASE_HOST: ${{ secrets.RELEASE_PROJECT_ID }}
   CHART_DIRECTORY: _infra/helm/responses-dashboard
   SPINNAKER_TOPIC: ${{ secrets.SPINNAKER_TOPIC }}
   ARTIFACT_BUCKET: ${{ secrets.ARTIFACT_BUCKET }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,8 +12,7 @@ env:
   IMAGE: responses-dashboard
   REGISTRY_HOSTNAME: europe-west2-docker.pkg.dev
   HOST: ${{ secrets.GOOGLE_PROJECT_ID }}
-#  GAR_REPOSITORY: ${{ secrets.GAR_REPOSITORY }}
-  GAR_REPOSITORY: ons-ci-rmrasbs
+  GAR_REPOSITORY: ${{ secrets.GAR_REPOSITORY }}
   RELEASE_HOST: ${{ secrets.RELEASE_PROJECT_ID }}
   CHART_DIRECTORY: _infra/helm/responses-dashboard
   SPINNAKER_TOPIC: ${{ secrets.SPINNAKER_TOPIC }}
@@ -64,7 +63,7 @@ jobs:
       - name: Build Docker Image
         if: github.ref != 'refs/heads/main'
         run: |
-          docker build -t "$REGISTRY_HOSTNAME"/"$HOST"/"$GAR_REPOSITORY"/"$IMAGE":${{ steps.tag.outputs.pr_number }} -f _infra/docker/Dockerfile .
+          docker build -t "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$GAR_REPOSITORY"/"$IMAGE":${{ env.pr_number }} -f _infra/docker/Dockerfile .
       - name: Push dev image
         if: github.ref != 'refs/heads/main'
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,8 @@ env:
   IMAGE: responses-dashboard
   REGISTRY_HOSTNAME: europe-west2-docker.pkg.dev
   HOST: ${{ secrets.GOOGLE_PROJECT_ID }}
-  GAR_REPOSITORY: ${{ secrets.GAR_REPOSITORY }}
+#  GAR_REPOSITORY: ${{ secrets.GAR_REPOSITORY }}
+  GAR_REPOSITORY: ons-ci-rmrasbs
   RELEASE_HOST: ${{ secrets.RELEASE_PROJECT_ID }}
   CHART_DIRECTORY: _infra/helm/responses-dashboard
   SPINNAKER_TOPIC: ${{ secrets.SPINNAKER_TOPIC }}

--- a/_infra/helm/responses-dashboard/Chart.yaml
+++ b/_infra/helm/responses-dashboard/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.40
+version: 2.0.41
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.0.40
+appVersion: 2.0.41

--- a/_infra/helm/responses-dashboard/values.yaml
+++ b/_infra/helm/responses-dashboard/values.yaml
@@ -3,6 +3,7 @@ namespace: dev
 publicIP: false
 
 image:
+  devRepo: europe-west2-docker.pkg.dev/ons-ci-rmrasbs/images
   name: europe-west2-docker.pkg.dev/ons-ci-rmrasbs/images
   tag: latest
   pullPolicy: Always

--- a/_infra/helm/responses-dashboard/values.yaml
+++ b/_infra/helm/responses-dashboard/values.yaml
@@ -3,7 +3,7 @@ namespace: dev
 publicIP: false
 
 image:
-  name: eu.gcr.io/ons-rasrmbs-management
+  name: europe-west2-docker.pkg.dev/ons-ci-rmrasbs/images
   tag: latest
   pullPolicy: Always
 


### PR DESCRIPTION
# What and why?
We need to migrate our images over from using GCR to using GAR. This PR accomplishes this.

# How to test?
Check image is in the correct GAR repo: https://console.cloud.google.com/artifacts/docker/ons-ci-rmrasbs/europe-west2/images/responses-dashboard?project=ons-ci-rmrasbs

Build out you environment. Once completed, goto: https://spin-deck.rmrasbs.gcp.onsdigital.uk/#/applications/responses-dashboard/executions?pipeline=Deploy%20Version and start a manual execution. Update the "namespace" to match your namespace, change the "tag" to "pr-169" and change the "configBranch" to "migrate-from-gcr-to-gar". Start the execution and once finished, check that the dashboard deployed correctly and has the following under "Revision History": `responses-dashboard: europe-west2-docker.pkg.dev/ons-ci-rmrasbs/images/responses-dashboard:pr-169`

The config PR can be found here: https://github.com/ONSdigital/ras-rm-config/pull/261

# Jira
https://jira.ons.gov.uk/browse/RAS-1154