### PR TITLE
change responses dashboard logging levels to error

### DIFF
--- a/_infra/helm/responses-dashboard/Chart.yaml
+++ b/_infra/helm/responses-dashboard/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.51
+version: 2.0.52
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.0.51
+appVersion: 2.0.52

--- a/app/api/reporting.py
+++ b/app/api/reporting.py
@@ -15,17 +15,17 @@ logger = get_logger()
 @reporting_blueprint.route("/reporting/survey/<survey_id>/collection-exercise/<collex_id>", methods=["GET"])
 def reporting_details(survey_id, collex_id):
     if not parse_uuid(survey_id):
-        logger.info("Malformed survey ID", survey_id=survey_id)
+        logger.error("Malformed survey ID", survey_id=survey_id)
         abort(404, "Malformed survey ID")
 
     if not parse_uuid(collex_id):
-        logger.info("Malformed collection exercise ID", collex_id=collex_id)
+        logger.error("Malformed collection exercise ID", collex_id=collex_id)
         abort(404, "Malformed collection exercise ID")
 
     try:
         report = get_reporting_details(survey_id, collex_id)
     except HTTPError:
-        logger.info("Invalid collection exercise or survey id")
+        logger.error("Invalid collection exercise or survey id")
         abort(404)
 
     return json.dumps(report)


### PR DESCRIPTION
# What and why?
Changing the logging levels of responses-dashboard-related logs to `error` so we can have better visualisation of the issues affecting the responses dashboard in preprod.

# How to test?
Just make sure the changes look okay.

# Jira
[Card](https://officefornationalstatistics.atlassian.net/jira/software/c/projects/RAS/boards/1943?selectedIssue=RAS-1685)
