### PR TITLE
Typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ pip install --U pip setuptools pipenv
 
 **Run with Make:**
 
-Compile static asssets with
+Compile static assets with
 ```bash
 make compile
 ```


### PR DESCRIPTION
# What and why?

Replaced `asssets` with `assets`.